### PR TITLE
fix circleci : PGP error cannot find public key 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ install_jdk: &install_jdk
       command: |
         while $(ps aux | grep -i ' apt ' | grep -v grep > /dev/null); do sleep 1; done # Wait for apt to be ready
         sudo add-apt-repository ppa:openjdk-r/ppa -y
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA
+
         sudo apt update
         sudo apt install openjdk-${JDK_VERSION}-jdk -y
 


### PR DESCRIPTION
currently build failed on master due to this error when installing opendjdk

```
W: GPG error: http://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 78BD65473CB3BD13
 
E: The repository 'http://dl.google.com/linux/chrome/deb stable InRelease' is not signed.
 
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
 
N: See apt-secure(8) manpage for repository creation and user configuration details.
 
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://cli-assets.heroku.com/apt ./ InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 5DC22404A6F9F1CA
```

fix circleci : PGP error cannot find public key 