### PR TITLE
UnsecureFtp - expose failure in error channel for readFile()

### DIFF
--- a/src/main/scala/zio/ftp/SecureFtp.scala
+++ b/src/main/scala/zio/ftp/SecureFtp.scala
@@ -137,7 +137,7 @@ object SecureFtp {
 
         new SecureFtp(ssh.newSFTPClient())
       }.mapError(ConnectionError(s"Fail to connect to server ${settings.host}:${settings.port}", _))
-    )(cli => { cli.execute(_.close()) >>= (_ => effectBlocking(ssh.disconnect()).whenM(URIO(ssh.isConnected))) }.ignore)
+    )(cli => { cli.execute(_.close()) *> effectBlocking(ssh.disconnect()).whenM(URIO(ssh.isConnected)) }.ignore)
   }
 
   private[this] def setIdentity(identity: SftpIdentity, username: String)(ssh: SSHClient): Unit = {

--- a/src/main/scala/zio/ftp/SecureFtp.scala
+++ b/src/main/scala/zio/ftp/SecureFtp.scala
@@ -137,9 +137,7 @@ object SecureFtp {
 
         new SecureFtp(ssh.newSFTPClient())
       }.mapError(ConnectionError(s"Fail to connect to server ${settings.host}:${settings.port}", _))
-    )(cli =>
-      cli.execute(_.close()).ignore >>= (_ => effectBlocking(ssh.disconnect()).whenM(URIO(ssh.isConnected)).ignore)
-    )
+    )(cli => { cli.execute(_.close()) >>= (_ => effectBlocking(ssh.disconnect()).whenM(URIO(ssh.isConnected))) }.ignore)
   }
 
   private[this] def setIdentity(identity: SftpIdentity, username: String)(ssh: SSHClient): Unit = {

--- a/src/main/scala/zio/ftp/errors.scala
+++ b/src/main/scala/zio/ftp/errors.scala
@@ -26,4 +26,4 @@ object ConnectionError {
 
 final case class InvalidPathError(message: String) extends IOException(message)
 
-final case class FileTransferIncompleteError(message: String, cause: Throwable) extends IOException(message)
+final case class FileTransferIncompleteError(message: String) extends IOException(message)

--- a/src/main/scala/zio/ftp/errors.scala
+++ b/src/main/scala/zio/ftp/errors.scala
@@ -18,10 +18,12 @@ package zio.ftp
 
 import java.io.IOException
 
-case class ConnectionError(message: String, cause: Throwable) extends IOException(message, cause)
+final case class ConnectionError(message: String, cause: Throwable) extends IOException(message, cause)
 
 object ConnectionError {
   def apply(message: String): ConnectionError = new ConnectionError(message, new Throwable(message))
 }
 
-case class InvalidPathError(message: String) extends IOException(message)
+final case class InvalidPathError(message: String) extends IOException(message)
+
+final case class FileTransferIncompleteError(message: String, cause: Throwable) extends IOException(message)

--- a/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
+++ b/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
@@ -1,0 +1,70 @@
+package zio.ftp
+
+import org.apache.commons.net.ftp.FTPClient
+import zio._
+import zio.ftp.UnsecureFtp.Client
+import zio.test.Assertion._
+import zio.test._
+
+import java.io.InputStream
+import scala.util.Random
+
+object UnsecureDownloadFinalizeSpec extends DefaultRunnableSpec {
+  private val fakeFileName = "/a/b/c.txt"
+
+  private def createFtp(
+    completeCallCount: Ref[Int],
+    rt: Runtime[Any],
+    failComplete: Boolean,
+    fileSize: Int = 5000
+  ) = {
+    val errorFinalizerClient = new FTPClient {
+
+      override def retrieveFileStream(remote: String): InputStream = {
+        val it = Random.alphanumeric.take(fileSize).map(_.toByte).iterator
+        () => if (it.hasNext) it.next().toInt else -1
+      }
+
+      override def completePendingCommand(): Boolean =
+        rt.unsafeRun(completeCallCount.update(_ + 1).as(!failComplete))
+    }
+
+    new UnsecureFtp(errorFinalizerClient)
+  }
+
+  private def createFtpZio(fileSize: Int = 5000, failComplete: Boolean = true) =
+    for {
+      ref <- Ref.make(0)
+      rt  <- ZIO.runtime[Any]
+    } yield createFtp(ref, rt, failComplete, fileSize)
+
+  private def callDownload(ftp: FtpAccessors[Client]) =
+    ftp.readFile(fakeFileName).runCollect
+
+  private def hasIncompleteMsg(a: Assertion[String]) =
+    hasField("file transfer incomplete message", (e: FileTransferIncompleteError) => e.message, a)
+
+  final val spec = suite("Download finalizer")(
+    testM("complete pending command gets called") {
+      for {
+        ref           <- Ref.make(0)
+        rt            <- ZIO.runtime[Any]
+        ftp            = createFtp(ref, rt, failComplete = false)
+        bytes         <- callDownload(ftp)
+        completeCount <- ref.get
+      } yield assertTrue(completeCount == 1) && assert(bytes)(hasSize(equalTo(5000)))
+    },
+    testM("completion failure is exposed on error channel") {
+      for {
+        ftp  <- createFtpZio()
+        exit <- callDownload(ftp).run
+      } yield assert(exit)(
+        fails(
+          isSubtype[FileTransferIncompleteError](
+            hasIncompleteMsg(startsWithString("Cannot finalize the file transfer") && containsString(fakeFileName))
+          )
+        )
+      )
+    }
+  )
+}


### PR DESCRIPTION
@codingismy11to7 it should resolve the issue :) Tell me what you think.

You can now recover the exception from the specific Error `FileTransferIncompleteError` with `.catchSome()`.

Thanks again for your review, i wrote the code a little bit too fast with my kids around...

I need to provide unit test but dont have yet a strategy to fail the download (maybe use mock 😢 )