### PR TITLE
Unsecure FTP downloads fix

### DIFF
--- a/src/main/scala/zio/ftp/SecureFtp.scala
+++ b/src/main/scala/zio/ftp/SecureFtp.scala
@@ -137,9 +137,7 @@ object SecureFtp {
 
         new SecureFtp(ssh.newSFTPClient())
       }.mapError(ConnectionError(s"Fail to connect to server ${settings.host}:${settings.port}", _))
-    )(cli =>
-      cli.execute(_.close()).ignore >>= (_ => effectBlocking(ssh.disconnect()).whenM(URIO(ssh.isConnected)).ignore)
-    )
+    )(cli => { cli.execute(_.close()) *> effectBlocking(ssh.disconnect()).whenM(URIO(ssh.isConnected)) }.ignore)
   }
 
   private[this] def setIdentity(identity: SftpIdentity, username: String)(ssh: SSHClient): Unit = {

--- a/src/main/scala/zio/ftp/UnsecureFtp.scala
+++ b/src/main/scala/zio/ftp/UnsecureFtp.scala
@@ -15,12 +15,13 @@
  */
 package zio.ftp
 
-import java.io.{ IOException, InputStream }
 import org.apache.commons.net.ftp.{ FTP, FTPClient => JFTPClient, FTPSClient => JFTPSClient }
 import zio.blocking._
 import zio.ftp.UnsecureFtp.Client
 import zio.stream.{ Stream, ZStream }
-import zio.{ Task, UIO, ZIO, ZManaged }
+import zio.{ ZIO, ZManaged }
+
+import java.io.IOException
 
 /**
  * Unsecure Ftp client wrapper
@@ -34,32 +35,16 @@ final private class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
     execute(c => Option(c.mlistFile(path))).map(_.map(FtpResource.fromFtpFile(_)))
 
   def readFile(path: String, chunkSize: Int = 2048): ZStream[Blocking, IOException, Byte] = {
-    val terminate = execute(_.completePendingCommand()).flatMap {
-      case false =>
-        ZIO.fail(new IOException(s"Cannot finalize the file transfer and complete to read the entire file $path."))
-      case _     => ZIO.unit
-    }.orDie
+    val terminate = ZIO
+      .fail(
+        FileTransferIncompleteError(s"Cannot finalize the file transfer and completely read the entire file $path.")
+      )
+      .unlessM(execute(_.completePendingCommand()))
 
-    for {
-      is   <- ZStream.fromEffect(
-                execute(c => Option(c.retrieveFileStream(path)))
-                  .flatMap(
-                    _.fold[ZIO[Any, InvalidPathError, InputStream]](
-                      ZIO.fail(InvalidPathError(s"File does not exist $path"))
-                    )(
-                      ZIO.succeed(_)
-                    )
-                  )
-              )
+    val inputStream =
+      execute(c => Option(c.retrieveFileStream(path))).someOrFail(InvalidPathError(s"File does not exist $path"))
 
-      data <- ZStream.fromInputStreamManaged(
-                ZManaged
-                  .make(Task(is))(a => UIO(a.close()) *> terminate)
-                  .mapError(e => new IOException(e.getMessage, e)),
-                chunkSize
-              )
-
-    } yield data
+    ZStream.fromInputStreamEffect(inputStream, chunkSize) ++ ZStream.fromEffect(terminate) *> ZStream.empty
   }
 
   def rm(path: String): ZIO[Blocking, IOException, Unit] =

--- a/src/main/scala/zio/ftp/errors.scala
+++ b/src/main/scala/zio/ftp/errors.scala
@@ -18,10 +18,12 @@ package zio.ftp
 
 import java.io.IOException
 
-case class ConnectionError(message: String, cause: Throwable) extends IOException(message, cause)
+final case class ConnectionError(message: String, cause: Throwable) extends IOException(message, cause)
 
 object ConnectionError {
   def apply(message: String): ConnectionError = new ConnectionError(message, new Throwable(message))
 }
 
-case class InvalidPathError(message: String) extends IOException(message)
+final case class InvalidPathError(message: String) extends IOException(message)
+
+final case class FileTransferIncompleteError(message: String) extends IOException(message)

--- a/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
+++ b/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
@@ -1,0 +1,48 @@
+package zio.ftp
+
+import org.apache.commons.net.ftp.FTPClient
+import zio.test.Assertion._
+import zio.test._
+
+import java.io.InputStream
+import scala.util.Random
+
+object UnsecureDownloadFinalizeSpec extends DefaultRunnableSpec {
+
+  private def createFtpclient(success: Boolean) = {
+    val client = new FTPClient {
+      override def retrieveFileStream(remote: String): InputStream = {
+        val it = Random.alphanumeric.take(5000).map(_.toByte).iterator
+        () => if (it.hasNext) it.next().toInt else -1
+      }
+
+      override def completePendingCommand(): Boolean = success
+    }
+
+    new UnsecureFtp(client)
+  }
+
+  private def hasIncompleteMsg(a: Assertion[String]) =
+    hasField("file transfer incomplete message", (e: FileTransferIncompleteError) => e.message, a)
+
+  final val spec = suite("Download finalizer")(
+    testM("complete pending command gets called") {
+      val ftpClient = createFtpclient(true)
+      for {
+        bytes <- ftpClient.readFile("/a/b/c.txt").runCollect
+      } yield assert(bytes)(hasSize(equalTo(5000)))
+    },
+    testM("completion failure is exposed on error channel") {
+      val ftpClient = createFtpclient(false)
+      for {
+        exit <- ftpClient.readFile("/a/b/c.txt").runCollect.run
+      } yield assert(exit)(
+        fails(
+          isSubtype[FileTransferIncompleteError](
+            hasIncompleteMsg(startsWithString("Cannot finalize the file transfer") && containsString("/a/b/c.txt"))
+          )
+        )
+      )
+    }
+  )
+}


### PR DESCRIPTION
- Add a unit test that ensures the finalizer is called and errors are propagated on error channel
- Fix the readFile code so the error is propagated on the error channel
- clean up readFile slightly (an inputstream was created in a ZStream, which was evaluated, and then the inputstream was wrapped in another ZIO; split it up so it does less work)