### PR TITLE
Support the dataTimeout FTPClient setting

### DIFF
--- a/src/main/scala/zio/ftp/FtpSettings.scala
+++ b/src/main/scala/zio/ftp/FtpSettings.scala
@@ -19,6 +19,7 @@ package zio.ftp
 import java.net.Proxy
 import java.nio.file.Path
 import net.schmizz.sshj.{ Config => SshConfig, DefaultConfig => DefaultSshConfig }
+import zio.duration.Duration
 
 /**
  * Credential used during ftp authentication
@@ -132,6 +133,8 @@ object KeyFileSftpIdentity {
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
  * @param proxy An optional proxy to use when connecting with these settings
+ * @param secure Use FTP over SSL
+ * @param dataTimeout Sets the timeout to use when reading from the data connection.
  */
 final case class UnsecureFtpSettings(
   host: String,
@@ -140,7 +143,8 @@ final case class UnsecureFtpSettings(
   binary: Boolean,
   passiveMode: Boolean,
   proxy: Option[Proxy],
-  secure: Boolean
+  secure: Boolean,
+  dataTimeout: Option[Duration] = None
 )
 
 object UnsecureFtpSettings {

--- a/src/main/scala/zio/ftp/UnsecureFtp.scala
+++ b/src/main/scala/zio/ftp/UnsecureFtp.scala
@@ -110,6 +110,9 @@ object UnsecureFtp {
 
         if (settings.passiveMode)
           ftpClient.enterLocalPassiveMode()
+
+        settings.dataTimeout.map(_.toMillis.toInt).foreach(ftpClient.setDataTimeout)
+
         new UnsecureFtp(ftpClient) -> success
       }.mapError(e => ConnectionError(e.getMessage, e))
         .filterOrFail(_._2)(ConnectionError(s"Fail to connect to server ${settings.host}:${settings.port}"))


### PR DESCRIPTION
Allows the user to easily set the data timeout setting on FTPClient, which is used as the socket timeout on file transfers. Keeps misbehaving servers from permanently stopping file transfer processing