### PR TITLE
support setting control encoding

### DIFF
--- a/src/main/scala/zio/ftp/FtpSettings.scala
+++ b/src/main/scala/zio/ftp/FtpSettings.scala
@@ -135,6 +135,7 @@ object KeyFileSftpIdentity {
  * @param proxy An optional proxy to use when connecting with these settings
  * @param secure Use FTP over SSL
  * @param dataTimeout Sets the timeout to use when reading from the data connection.
+ * @param controlEncoding character encoding to be used by the FTP control connection, auto-detects UTF-8 if None
  */
 final case class UnsecureFtpSettings(
   host: String,
@@ -144,7 +145,8 @@ final case class UnsecureFtpSettings(
   passiveMode: Boolean,
   proxy: Option[Proxy],
   secure: Boolean,
-  dataTimeout: Option[Duration] = None
+  dataTimeout: Option[Duration] = None,
+  controlEncoding: Option[String] = None
 )
 
 object UnsecureFtpSettings {

--- a/src/main/scala/zio/ftp/UnsecureFtp.scala
+++ b/src/main/scala/zio/ftp/UnsecureFtp.scala
@@ -100,6 +100,12 @@ object UnsecureFtp {
     ZManaged.make(
       effectBlockingIO {
         val ftpClient = if (settings.secure) new JFTPSClient() else new JFTPClient()
+
+        settings.controlEncoding match {
+          case Some(enc) => ftpClient.setControlEncoding(enc)
+          case None      => ftpClient.setAutodetectUTF8(true)
+        }
+
         settings.proxy.foreach(ftpClient.setProxy)
         ftpClient.connect(settings.host, settings.port)
 


### PR DESCRIPTION
in the unset case, try to auto-detect UTF-8 (which seems to be the current norm)