### PR TITLE
if a data timeout is provided, honor it for the retrieve file finalizer

### DIFF
--- a/src/main/scala/zio/ftp/package.scala
+++ b/src/main/scala/zio/ftp/package.scala
@@ -19,6 +19,7 @@ package zio
 import java.io.IOException
 
 import zio.blocking.Blocking
+import zio.clock.Clock
 import zio.nio.file.{ Path => ZPath }
 import zio.stream.ZStream
 
@@ -129,7 +130,7 @@ package object ftp {
       ZStream.accessStream(_.get.readFile(path, chunkSize))
   }
 
-  def unsecure(settings: UnsecureFtpSettings): ZLayer[Blocking, ConnectionError, Ftp] =
+  def unsecure(settings: UnsecureFtpSettings): ZLayer[Blocking with Clock, ConnectionError, Ftp] =
     ZLayer.fromManaged(UnsecureFtp.connect(settings))
 
   def secure(settings: SecureFtpSettings): ZLayer[Blocking, ConnectionError, SFtp] =

--- a/src/test/scala/zio/ftp/Ftpspec.scala
+++ b/src/test/scala/zio/ftp/Ftpspec.scala
@@ -4,6 +4,7 @@ import java.net.{ InetSocketAddress, Proxy }
 
 import zio._
 import zio.blocking.Blocking
+import zio.clock.Clock
 import zio.ftp.Ftp._
 import zio.nio.file.{ Path => ZPath }
 import zio.nio.file.Files
@@ -17,7 +18,7 @@ import scala.io.Source
 object FtpsTest extends DefaultRunnableSpec {
   val settings = UnsecureFtpSettings.secure("127.0.0.1", 2121, FtpCredentials("username", "userpass"))
 
-  val ftp = Blocking.live >>> unsecure(settings).mapError(TestFailure.die(_))
+  val ftp = unsecure(settings).mapError(TestFailure.die(_))
 
   override def spec =
     FtpSuite.spec("FtpsSpec", settings).provideCustomLayer(ftp) @@ sequential
@@ -25,7 +26,7 @@ object FtpsTest extends DefaultRunnableSpec {
 
 object FtpTest extends DefaultRunnableSpec {
   val settings = UnsecureFtpSettings("127.0.0.1", port = 2121, FtpCredentials("username", "userpass"))
-  val ftp      = Blocking.live >>> unsecure(settings).mapError(TestFailure.die(_))
+  val ftp      = unsecure(settings).mapError(TestFailure.die(_))
 
   override def spec =
     FtpSuite.spec("FtpSpec", settings).provideCustomLayer(ftp) @@ sequential
@@ -37,7 +38,7 @@ object FtpSuite {
   def spec(
     labelSuite: String,
     settings: UnsecureFtpSettings
-  ): Spec[Ftp with Blocking, TestFailure[Throwable], TestSuccess] =
+  ): Spec[Ftp with Blocking with Clock, TestFailure[Throwable], TestSuccess] =
     suite(labelSuite)(
       testM("invalid credentials")(
         for {

--- a/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
+++ b/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
@@ -1,6 +1,9 @@
 package zio.ftp
 
 import org.apache.commons.net.ftp.FTPClient
+import zio._
+import zio.clock.Clock
+import zio.duration._
 import zio.test.Assertion._
 import zio.test._
 
@@ -9,33 +12,40 @@ import scala.util.Random
 
 object UnsecureDownloadFinalizeSpec extends DefaultRunnableSpec {
 
-  private def createFtpclient(success: Boolean) = {
-    val client = new FTPClient {
-      override def retrieveFileStream(remote: String): InputStream = {
-        val it = Random.alphanumeric.take(5000).map(_.toByte).iterator
-        () => if (it.hasNext) it.next().toInt else -1
+  private def createFtpclient(success: Boolean) =
+    for {
+      clock <- ZIO.service[Clock.Service]
+    } yield {
+      val client = new FTPClient {
+        override def retrieveFileStream(remote: String): InputStream = {
+          val it = Random.alphanumeric.take(5000).map(_.toByte).iterator
+          () => if (it.hasNext) it.next().toInt else -1
+        }
+
+        override def completePendingCommand(): Boolean = success
       }
 
-      override def completePendingCommand(): Boolean = success
+      new UnsecureFtp(client, Some(5.seconds), clock)
     }
 
-    new UnsecureFtp(client)
-  }
+  private def readFile(success: Boolean) =
+    for {
+      ftpClient <- createFtpclient(success)
+      bytes     <- ftpClient.readFile("/a/b/c.txt").runCollect
+    } yield bytes
 
   private def hasIncompleteMsg(a: Assertion[String]) =
     hasField("file transfer incomplete message", (e: FileTransferIncompleteError) => e.message, a)
 
   final val spec = suite("Download finalizer")(
     testM("complete pending command gets called") {
-      val ftpClient = createFtpclient(true)
       for {
-        bytes <- ftpClient.readFile("/a/b/c.txt").runCollect
+        bytes <- readFile(success = true)
       } yield assert(bytes)(hasSize(equalTo(5000)))
     },
     testM("completion failure is exposed on error channel") {
-      val ftpClient = createFtpclient(false)
       for {
-        exit <- ftpClient.readFile("/a/b/c.txt").runCollect.run
+        exit <- readFile(success = false).run
       } yield assert(exit)(
         fails(
           isSubtype[FileTransferIncompleteError](


### PR DESCRIPTION
So we added the finalizer to ensure that multiple downloads on the same connection don't fail, but there was no timeout on that completePending call. In my real-world tests, I've seen that freeze with no connection error so that the program eventually dies (as in all connections freeze on that call and nothing continues running, not that the program crashes).

I wrote this code so that if a data timeout is provided in the ftp settings, it will also be applied for the complete pending portion of downloads. In my real-world tests it's been running non-stop for 6 days with no problems (my program would freeze at least daily before), and I wrote a unit test to ensure this code works.

Unfortunately, I'm running ZIO2 with a locally-built zio-ftp library, so I wrote this code and the unit test against that. When I tried to backport everything to ZIO1, the unit test fails every time. I'm presuming this would work in the real world on ZIO1, the code isn't that complicated and I didn't have to change any of it for the backport (just the stuff dealing with layers that has changed).

I opened an issue with ZIO about not being able to test this properly: https://github.com/zio/zio/issues/6255

I'll leave this for you to decide what to do with it, I think the code is good and it works for me on ZIO2, but it definitely would be nice to have a unit test covering it. maybe the existing tests using docker will give you enough assurance. (on that note, I'd add a test that tries multiple downloads on the same connection that would have broken before the finalization call was added)