### PR TITLE
remove unneeded Scope requirement in FtpAccessors

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3.5.1
+      uses: actions/checkout@v3.3.0
       with:
         fetch-depth: '0'
     - name: Setup Scala
@@ -41,7 +41,7 @@ jobs:
     if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3.5.1
+      uses: actions/checkout@v3.3.0
       with:
         fetch-depth: '0'
     - name: Setup Scala
@@ -65,7 +65,7 @@ jobs:
     if: ${{ (github.event_name == 'push') || ((github.event_name == 'release') && (github.event_name == 'published')) }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v3.5.1
+      uses: actions/checkout@v3.3.0
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: '0'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.0" 
+libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.1" 
 ```
 
 ## How to use it?

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ object ZIOFTPExample extends ZIOAppDefault {
   private val settings =
     UnsecureFtpSettings("127.0.0.1", 21, FtpCredentials("one", "1234"))
 
-  private val myApp: ZIO[Scope with Ftp, IOException, Unit] =
+  private val myApp: ZIO[Ftp, IOException, Unit] =
     for {
       _        <- Console.printLine("List of files at root directory:")
       resource <- ls("/").runCollect

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ object ZIOFTPExample extends ZIOAppDefault {
                     .via(ZPipeline.utf8Decode)
                     .runCollect
       _        <- Console.printLine(s"Content of $path file:")
-      _        <- Console.printLine(file.fold("")(_ + _))
+      _        <- Console.printLine(file.mkString)
     } yield ()
 
   override def run = myApp.provideSomeLayer(unsecure(settings))

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ object ZIOFTPExample extends ZIOAppDefault {
   private val settings =
     UnsecureFtpSettings("127.0.0.1", 21, FtpCredentials("one", "1234"))
 
-  private val myApp: ZIO[Scope with Ftp, IOException, Unit] =
+  private val myApp: ZIO[Ftp, IOException, Unit] =
     for {
       _        <- Console.printLine("List of files at root directory:")
       resource <- ls("/").runCollect

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ object ZIOFTPExample extends ZIOAppDefault {
                     .via(ZPipeline.utf8Decode)
                     .runCollect
       _        <- Console.printLine(s"Content of $path file:")
-      _        <- Console.printLine(file.fold("")(_ + _))
+      _        <- Console.printLine(file.mkString)
     } yield ()
 
   override def run = myApp.provideSomeLayer(unsecure(settings))

--- a/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
@@ -73,6 +73,6 @@ trait FtpAccessors[+A] {
    * @param source data stream to store
    * @tparam R environment of the specified stream source, required to extend Blocking
    */
-  def upload[R](path: String, source: ZStream[R, Throwable, Byte]): ZIO[R with Scope, IOException, Unit]
+  def upload[R](path: String, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit]
 
 }

--- a/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
@@ -1,7 +1,7 @@
 package zio.ftp
 
 import java.io.IOException
-import zio.{ Scope, ZIO }
+import zio.ZIO
 import zio.stream.ZStream
 
 trait FtpAccessors[+A] {

--- a/zio-ftp/src/main/scala/zio/ftp/package.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/package.scala
@@ -55,7 +55,7 @@ package object ftp {
     def upload[R](
       path: String,
       source: ZStream[R, Throwable, Byte]
-    ): ZIO[R & Scope with Ftp, IOException, Unit] =
+    ): ZIO[R with Ftp, IOException, Unit] =
       for {
         ftp <- ZIO.service[Ftp]
         _   <- ftp.upload(path, source)
@@ -91,7 +91,7 @@ package object ftp {
     def upload[R](
       path: String,
       source: ZStream[R, Throwable, Byte]
-    ): ZIO[SFtp with R with Scope, IOException, Unit] =
+    ): ZIO[SFtp with R, IOException, Unit] =
       for {
         ftp <- ZIO.service[SFtp]
         _   <- ftp.upload(path, source)
@@ -127,7 +127,7 @@ package object ftp {
     def upload[R](
       path: String,
       source: ZStream[R, Throwable, Byte]
-    ): ZIO[StubFtp with R with Scope, IOException, Unit] =
+    ): ZIO[StubFtp with R, IOException, Unit] =
       for {
         ftp <- ZIO.service[StubFtp]
         _   <- ftp.upload(path, source)

--- a/zio-ftp/src/main/scala/zio/ftp/package.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/package.scala
@@ -137,11 +137,11 @@ package object ftp {
       ZStream.serviceWithStream(_.readFile(path, chunkSize))
   }
 
-  def unsecure(settings: UnsecureFtpSettings): ZLayer[Scope, ConnectionError, Ftp] =
-    ZLayer.fromZIO(UnsecureFtp.connect(settings))
+  def unsecure(settings: UnsecureFtpSettings): ZLayer[Any, ConnectionError, Ftp] =
+    ZLayer.scoped(UnsecureFtp.connect(settings))
 
-  def secure(settings: SecureFtpSettings): ZLayer[Scope, ConnectionError, SFtp] =
-    ZLayer.fromZIO(SecureFtp.connect(settings))
+  def secure(settings: SecureFtpSettings): ZLayer[Any, ConnectionError, SFtp] =
+    ZLayer.scoped(SecureFtp.connect(settings))
 
   def stub(path: ZPath): Layer[Any, StubFtp] =
     ZLayer.succeed(TestFtp.create(path))


### PR DESCRIPTION
zio-ftp opens some streams to upload files, but it doesn't close them and thus leaks the `Scope` requirement. There's no reason to keep these streams open after uploading has completed, so let's just close them and remove the `Scope` requirement.