### PR TITLE
UnsecureFtp: improve `readFile` Stream finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.1" 
+libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.2" 
 ```
 
 ## How to use it?

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.10.1

--- a/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala
@@ -42,12 +42,22 @@ final private class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
       execute { c =>
         val r = Option(c.retrieveFileStream(path))
         if (FTPReply.isPositivePreliminary(c.getReplyCode())) {
-          pendingExit =
-            Some(Exit.die(new IllegalStateException("The ZStream returned by `readFile` must be finalized before further interactions with the FTP client")))
+          pendingExit = Some(
+            Exit.die(
+              new IllegalStateException(
+                "The ZStream returned by `readFile` must be finalized before further interactions with the FTP client"
+              )
+            )
+          )
           ZStream
-            .fromInputStreamZIO(  
-              ZIO.succeed(r)
-                .someOrFail(new IllegalStateException("FTP client reported preliminary success but returned null. This shouldn't happen..."))
+            .fromInputStreamZIO(
+              ZIO
+                .succeed(r)
+                .someOrFail(
+                  new IllegalStateException(
+                    "FTP client reported preliminary success but returned null. This shouldn't happen..."
+                  )
+                )
                 .orDie,
               chunkSize
             )
@@ -63,7 +73,7 @@ final private class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
                 .exit
                 .flatMap { e =>
                   ZIO.succeed {
-                    pendingExit = Some(e) 
+                    pendingExit = Some(e)
                   }
                 }
             }

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
@@ -39,9 +39,6 @@ object UnsecureDownloadFinalizeSpec extends ZIOSpecDefault {
         }
         for {
           bytes <- ftpClient.readFile("/a/b/c.txt").runCollect
-          _     <- ftpClient
-                     .readFile("/a/b/c.txt")
-                     .runCollect // completePendingCommand is only called when the next command is executed
         } yield assert(bytes)(hasSize(equalTo(FileSize))) && assertTrue(completePendingCommandWasCalled)
       },
       test("completion failure is exposed on error channel") {


### PR DESCRIPTION
Hi there,

I recently noticed a problem with zio-ftp. I was trying to read a zip file from the server using [`java.util.zip.ZipInputStream`](https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/java.base/java/util/zip/ZipInputStream.html).
So I was just iterating over the entries in the zip file, reading the data from the entries that I'm interested in and it all worked beautifully… until I tried to read another file from the FTP server, which resulted in a file not found error, even though I knew the file was there.
It turns out that iterating over a zip archive with `ZipInputStream` never results in an attempt to read beyond the end of the file. But due to [the way that finalization of the stream is implemented](https://github.com/zio/zio-ftp/blob/91350dd0a525e6d0583974698bf5dd7c919777d2/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala#L46) (using the `++` operator on a stream), this means that `completePendingCommand` isn't called, resulting in the problem I've seen.
This might also be the reason for bug #227.

The solution is to use `.ensuring` for the finalizer. This has the added benefit that it's now possible to read only part of the file and stop processing once you've found the bit you're interested in.
But it leads to another problem: finalizers aren't allowed to throw errors, but `completePendingCommand` can fail. I could `die` in that situation, but that doesn't seem right, because `die` indicates a defect in the program, and when the FTP server decides to be weird, that's not the program's fault. Therefore, I decided to not throw the error from the finalizer but instead delay the error until the next `execute` call.
I've also improved the error handling so that it doesn't just assume a "File doesn't exist" error but instead exposes the error message given by the FTP server to make it more transparent what's going on.
