### PR TITLE
Expose `readFile` with an `InputStream` return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.1" 
+libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.2" 
 ```
 
 ## How to use it?

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.10.1

--- a/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
@@ -1,8 +1,9 @@
 package zio.ftp
 
 import java.io.IOException
-import zio.ZIO
+import zio.{ Scope, ZIO }
 import zio.stream.ZStream
+import java.io.InputStream
 
 trait FtpAccessors[+A] {
 
@@ -30,6 +31,7 @@ trait FtpAccessors[+A] {
    * @param fileOffset optional initial offset in bytes
    */
   def readFile(path: String, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[Any, IOException, Byte]
+  def readFileInputStream(path: String, fileOffset: Long): ZIO[Scope, IOException, InputStream]
 
   /**
    * Delete a file on a server. If the operation failed, an error will be emitted

--- a/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala
@@ -42,12 +42,22 @@ final private class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
       execute { c =>
         val r = Option(c.retrieveFileStream(path))
         if (FTPReply.isPositivePreliminary(c.getReplyCode())) {
-          pendingExit =
-            Some(Exit.die(new IllegalStateException("The ZStream returned by `readFile` must be finalized before further interactions with the FTP client")))
+          pendingExit = Some(
+            Exit.die(
+              new IllegalStateException(
+                "The ZStream returned by `readFile` must be finalized before further interactions with the FTP client"
+              )
+            )
+          )
           ZStream
-            .fromInputStreamZIO(  
-              ZIO.succeed(r)
-                .someOrFail(new IllegalStateException("FTP client reported preliminary success but returned null. This shouldn't happen..."))
+            .fromInputStreamZIO(
+              ZIO
+                .succeed(r)
+                .someOrFail(
+                  new IllegalStateException(
+                    "FTP client reported preliminary success but returned null. This shouldn't happen..."
+                  )
+                )
                 .orDie,
               chunkSize
             )
@@ -63,7 +73,7 @@ final private class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
                 .exit
                 .flatMap { e =>
                   ZIO.succeed {
-                    pendingExit = Some(e) 
+                    pendingExit = Some(e)
                   }
                 }
             }

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureDownloadFinalizeSpec.scala
@@ -39,9 +39,6 @@ object UnsecureDownloadFinalizeSpec extends ZIOSpecDefault {
         }
         for {
           bytes <- ftpClient.readFile("/a/b/c.txt").runCollect
-          _     <- ftpClient
-                     .readFile("/a/b/c.txt")
-                     .runCollect // completePendingCommand is only called when the next command is executed
         } yield assert(bytes)(hasSize(equalTo(FileSize))) && assertTrue(completePendingCommandWasCalled)
       },
       test("completion failure is exposed on error channel") {


### PR DESCRIPTION
Hey,

I noticed that both the UnsecureFtp and the SecureFtp implementations of the `readFile` method create the `ZStream` from a `java.io.InputStream`. I think it's fairly common to consume this data using Java libraries that require an `InputStream`, and hence I think it's useful to expose these `InputStream`s directly. While it's possible to turn a `ZStream` back into an `InputStream`, that seems convoluted and less efficient than just giving people access to the `InputStream` directly.

Note that this PR is based on #410 , so that PR should be merged first.