### PR TITLE
change `lastModified` to `Instant`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.2" 
+libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.3" 
 ```
 
 ## How to use it?

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -36,14 +36,10 @@ import scala.jdk.CollectionConverters._
 final case class FtpResource(
   path: String,
   size: Long,
-  lastModified: Long,
+  lastModified: Instant,
   permissions: Set[PosixFilePermission],
   isDirectory: Option[Boolean]
-) {
-
-  def lastModifiedInstant: Instant =
-    Instant.ofEpochMilli(lastModified)
-}
+)
 
 object FtpResource {
 
@@ -54,7 +50,7 @@ object FtpResource {
         case p   => s"$p/${f.getName}"
       },
       f.getSize,
-      f.getTimestamp.getTimeInMillis,
+      f.getTimestamp.toInstant(),
       getPosixFilePermissions(f),
       Some(f.isDirectory)
     )
@@ -63,13 +59,13 @@ object FtpResource {
     FtpResource(
       file.getPath,
       file.getAttributes.getSize,
-      file.getAttributes.getMtime * 1000,
+      Instant.ofEpochMilli(file.getAttributes.getMtime * 1000),
       posixFilePermissions(file.getAttributes),
       Some(file.isDirectory)
     )
 
   def apply(path: String, attr: FileAttributes): FtpResource =
-    FtpResource(path, attr.getSize, attr.getMtime * 1000, posixFilePermissions(attr), None)
+    FtpResource(path, attr.getSize, Instant.ofEpochMilli(attr.getMtime * 1000), posixFilePermissions(attr), None)
 
   private def getPosixFilePermissions(file: FTPFile) =
     Map(

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -59,13 +59,13 @@ object FtpResource {
     FtpResource(
       file.getPath,
       file.getAttributes.getSize,
-      Instant.ofEpochMilli(file.getAttributes.getMtime * 1000),
+      Instant.ofEpochSecond(file.getAttributes.getMtime),
       posixFilePermissions(file.getAttributes),
       Some(file.isDirectory)
     )
 
   def apply(path: String, attr: FileAttributes): FtpResource =
-    FtpResource(path, attr.getSize, Instant.ofEpochMilli(attr.getMtime * 1000), posixFilePermissions(attr), None)
+    FtpResource(path, attr.getSize, Instant.ofEpochSecond(attr.getMtime), posixFilePermissions(attr), None)
 
   private def getPosixFilePermissions(file: FTPFile) =
     Map(

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -18,6 +18,7 @@ package zio.ftp
 
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermission._
+import java.time.Instant
 import net.schmizz.sshj.sftp.{ FileAttributes, RemoteResourceInfo }
 import net.schmizz.sshj.xfer.FilePermission._
 import org.apache.commons.net.ftp.FTPFile
@@ -38,7 +39,11 @@ final case class FtpResource(
   lastModified: Long,
   permissions: Set[PosixFilePermission],
   isDirectory: Option[Boolean]
-)
+) {
+
+  def lastModifiedInstant: Instant =
+    Instant.ofEpochSecond(lastModified)
+}
 
 object FtpResource {
 

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -42,7 +42,7 @@ final case class FtpResource(
 ) {
 
   def lastModifiedInstant: Instant =
-    Instant.ofEpochSecond(lastModified)
+    Instant.ofEpochMilli(lastModified)
 }
 
 object FtpResource {
@@ -63,13 +63,13 @@ object FtpResource {
     FtpResource(
       file.getPath,
       file.getAttributes.getSize,
-      file.getAttributes.getMtime,
+      file.getAttributes.getMtime * 1000,
       posixFilePermissions(file.getAttributes),
       Some(file.isDirectory)
     )
 
   def apply(path: String, attr: FileAttributes): FtpResource =
-    FtpResource(path, attr.getSize, attr.getMtime, posixFilePermissions(attr), None)
+    FtpResource(path, attr.getSize, attr.getMtime * 1000, posixFilePermissions(attr), None)
 
   private def getPosixFilePermissions(file: FTPFile) =
     Map(

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -82,7 +82,7 @@ object TestFtp {
                               ZIO.succeed(Set.empty[PosixFilePermission])
                           }
           isDir        <- Files.isDirectory(p).map(Some(_))
-          lastModified <- Files.getLastModifiedTime(p).map(_.toMillis)
+          lastModified <- Files.getLastModifiedTime(p).map(_.toInstant())
           size         <- Files.size(p)
         } yield FtpResource(root.relativize(p).elements.mkString("/", "/", ""), size, lastModified, permissions, isDir))
           .mapError(new IOException(_))

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -11,6 +11,7 @@ import zio.test._
 import java.net.{ InetSocketAddress, Proxy }
 import java.nio.file.{ Files, Paths }
 import scala.io.Source
+import java.time.Instant
 
 object Load
 
@@ -70,7 +71,11 @@ object SecureFtpSpec extends ZIOSpecDefault {
       test("ls")(
         for {
           files <- ls("/").runCollect
-        } yield assert(files.map(_.path))(hasSameElements(List("/notes.txt", "/dir1")))
+        } yield assertTrue(
+          files.map(_.path).toSet == Set("/notes.txt", "/dir1") && files
+            .find(_.path == "/notes.txt")
+            .exists(_.lastModified == Instant.now())
+        )
       ),
       test("ls with invalid directory")(
         for {

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -12,6 +12,7 @@ import java.net.{ InetSocketAddress, Proxy }
 import java.nio.file.{ Files, Paths }
 import scala.io.Source
 import java.time.Instant
+import java.time.{ Duration => JDuration }
 
 object Load
 
@@ -74,7 +75,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
         } yield assertTrue(
           files.map(_.path).toSet == Set("/notes.txt", "/dir1") && files
             .find(_.path == "/notes.txt")
-            .exists(_.lastModified == Instant.now())
+            .exists(r => JDuration.between(r.lastModified, Instant.now()).abs.toMinutes < 10)
         )
       ),
       test("ls with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -12,6 +12,7 @@ import zio.stream.ZPipeline.utf8Decode
 import zio.stream.ZStream
 import java.net.{ InetSocketAddress, Proxy }
 import scala.io.Source
+import java.time.{ Instant, Duration => JDuration }
 
 object UnsecureSslFtpSpec extends ZIOSpecDefault {
   private val settings = UnsecureFtpSettings.secure("127.0.0.1", 2121, FtpCredentials("username", "userpass"))
@@ -59,6 +60,11 @@ object FtpSuite {
         for {
           files <- ls("/").runFold(List.empty[String])((s, f) => f.path +: s)
         } yield assert(files.reverse)(hasSameElements(List("/notes.txt", "/dir1")))
+      ),
+      test("timestamp")(
+        for {
+          file <- ls("/notes.txt").runLast
+        } yield assertTrue(file.exists(r => JDuration.between(r.lastModified, Instant.now()).abs.toMinutes < 10))
       ),
       test("ls with invalid directory")(
         for {


### PR DESCRIPTION
Just wrote a bug by confusing millis and seconds, and thought I'd make it easier for other people.

I thought about just changing the type of the field, but that would break compatibility. 