### PR TITLE
throw out zio-nio, use java.nio.file.Path for paths everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ libraryDependencies += "dev.zio" %% "zio-ftp" % "0.4.3"
 * Imports
 ```scala
 import zio.ftp._
+import java.nio.file.Paths
 ```
 
 * FTP
@@ -47,7 +48,7 @@ SFtp.ls("/").runCollect.provideLayer(secure(secureSettings))
 val sftpSettings = SecureFtpSettings("127.0.0.1", 22, FtpCredentials("foo", "bar"))
 
 //listing files
-SFtp.ls("/").runCollect.provideLayer(secure(sftpSettings))
+SFtp.ls(Paths.get("/")).runCollect.provideLayer(secure(sftpSettings))
 ```
 
 ## Example
@@ -81,9 +82,9 @@ object ZIOFTPExample extends ZIOAppDefault {
   private val myApp: ZIO[Ftp, IOException, Unit] =
     for {
       _        <- Console.printLine("List of files at root directory:")
-      resource <- ls("/").runCollect
+      resource <- ls(Paths.get("/")).runCollect
       _        <- ZIO.foreach(resource)(e => Console.printLine(e.path))
-      path      = "~/file.txt"
+      path      = Paths.get("~/file.txt")
       _        <- upload(
                     path,
                     ZStream.fromChunk(

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import java.nio.file.Paths
 val unsecureSettings = UnsecureFtpSettings("127.0.0.1", 21, FtpCredentials("foo", "bar"))
 
 //listing files
-Ftp.ls("/").runCollect.provideLayer(unsecure(unsecureSettings))
+Ftp.ls(Paths.get("/")).runCollect.provideLayer(unsecure(unsecureSettings))
 ```
 
 * FTPS
@@ -39,7 +39,7 @@ Ftp.ls("/").runCollect.provideLayer(unsecure(unsecureSettings))
 val secureSettings = SecureFtpSettings("127.0.0.1", 21, FtpCredentials("foo", "bar"))
 
 //listing files
-SFtp.ls("/").runCollect.provideLayer(secure(secureSettings))
+SFtp.ls(Paths.get("/")).runCollect.provideLayer(secure(secureSettings))
 ```
 
 * SFTP (support ssh key)

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ lazy val `zio-ftp` = project
     libraryDependencies ++= Seq(
       "dev.zio"                 %% "zio"                     % zioVersion,
       "dev.zio"                 %% "zio-streams"             % zioVersion,
-      ("dev.zio"                %% "zio-nio"                 % "2.0.2").exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
       "com.hierynomus"           % "sshj"                    % "0.39.0",
       "commons-net"              % "commons-net"             % "3.11.0",
       "org.scala-lang.modules"  %% "scala-collection-compat" % "2.12.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ import zio.ftp._
 val unsecureSettings = UnsecureFtpSettings("127.0.0.1", 21, FtpCredentials("foo", "bar"))
 
 //listing files
-Ftp.ls("/").runCollect.provideLayer(unsecure(unsecureSettings))
+Ftp.ls(Paths.get("/")).runCollect.provideLayer(unsecure(unsecureSettings))
 ```
 
 * FTPS
@@ -37,7 +37,7 @@ Ftp.ls("/").runCollect.provideLayer(unsecure(unsecureSettings))
 val secureSettings = SecureFtpSettings("127.0.0.1", 21, FtpCredentials("foo", "bar"))
 
 //listing files
-SFtp.ls("/").runCollect.provideLayer(secure(secureSettings))
+SFtp.ls(Paths.get("/")).runCollect.provideLayer(secure(secureSettings))
 ```
 
 * SFTP (support ssh key)
@@ -46,7 +46,7 @@ SFtp.ls("/").runCollect.provideLayer(secure(secureSettings))
 val sftpSettings = SecureFtpSettings("127.0.0.1", 22, FtpCredentials("foo", "bar"))
 
 //listing files
-SFtp.ls("/").runCollect.provideLayer(secure(sftpSettings))
+SFtp.ls(Paths.get("/")).runCollect.provideLayer(secure(sftpSettings))
 ```
 
 ## Example

--- a/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpAccessors.scala
@@ -3,6 +3,7 @@ package zio.ftp
 import java.io.IOException
 import zio.ZIO
 import zio.stream.ZStream
+import java.nio.file.Path
 
 trait FtpAccessors[+A] {
 
@@ -20,7 +21,7 @@ trait FtpAccessors[+A] {
    *
    * @param path absolute path of the file
    */
-  def stat(path: String): ZIO[Any, IOException, Option[FtpResource]]
+  def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]]
 
   /**
    * Read a file by using stream. If the operation failed, an error will be emitted
@@ -29,14 +30,14 @@ trait FtpAccessors[+A] {
    * @param chunkSize default chunk size is 2048 bytes
    * @param fileOffset optional initial offset in bytes
    */
-  def readFile(path: String, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[Any, IOException, Byte]
+  def readFile(path: Path, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[Any, IOException, Byte]
 
   /**
    * Delete a file on a server. If the operation failed, an error will be emitted
    *
    * @param path absolute path of the file
    */
-  def rm(path: String): ZIO[Any, IOException, Unit]
+  def rm(path: Path): ZIO[Any, IOException, Unit]
 
   /**
    * Delete a directory. If the operation failed, an error will be emitted
@@ -44,28 +45,28 @@ trait FtpAccessors[+A] {
    * @param path absolute path of the directory
    * @return
    */
-  def rmdir(path: String): ZIO[Any, IOException, Unit]
+  def rmdir(path: Path): ZIO[Any, IOException, Unit]
 
   /**
    * Create a directory. If the operation failed, an error will be emitted
    *
    * @param path absolute path of the directory
    */
-  def mkdir(path: String): ZIO[Any, IOException, Unit]
+  def mkdir(path: Path): ZIO[Any, IOException, Unit]
 
   /**
    * List of files / directories. If the operation failed, an error will be emitted
    *
    * @param path absolute path of the directory
    */
-  def ls(path: String): ZStream[Any, IOException, FtpResource]
+  def ls(path: Path): ZStream[Any, IOException, FtpResource]
 
   /**
    * List of files from a base directory recursively. If the operation failed, an error will be emitted
    *
    * @param path absolute path of the directory
    */
-  def lsDescendant(path: String): ZStream[Any, IOException, FtpResource]
+  def lsDescendant(path: Path): ZStream[Any, IOException, FtpResource]
 
   /**
    * Save a data stream. If the operation failed, an error will be emitted
@@ -74,7 +75,7 @@ trait FtpAccessors[+A] {
    * @param source data stream to store
    * @tparam R environment of the specified stream source, required to extend Blocking
    */
-  def upload[R](path: String, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit]
+  def upload[R](path: Path, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit]
 
   /**
    * Renames a file/directory. If the operation failed, an error will be emitted
@@ -82,6 +83,6 @@ trait FtpAccessors[+A] {
    * @param oldPath absolute path of the file/directory to rename
    * @param newPath absolute path of the file/directory destination.
    */
-  def rename(oldPath: String, newPath: String): ZIO[Any, IOException, Unit]
+  def rename(oldPath: Path, newPath: Path): ZIO[Any, IOException, Unit]
 
 }

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -46,7 +46,7 @@ object FtpResource {
 
   def fromFtpFile(f: FTPFile, path: Option[Path] = None): FtpResource =
     FtpResource(
-      path.foldLeft(Path.of(f.getName))(_.resolve(_)),
+      path.foldLeft(Path.of(f.getName))((a, b) => b.resolve(a)),
       f.getSize,
       f.getTimestamp.toInstant(),
       getPosixFilePermissions(f),

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -23,7 +23,7 @@ import net.schmizz.sshj.sftp.{ FileAttributes, RemoteResourceInfo }
 import net.schmizz.sshj.xfer.FilePermission._
 import org.apache.commons.net.ftp.FTPFile
 import scala.jdk.CollectionConverters._
-import java.nio.file.Path
+import java.nio.file.{ Path, Paths }
 
 /**
  * Represent a file / directory / symbolic link on a ftp server
@@ -46,7 +46,7 @@ object FtpResource {
 
   def fromFtpFile(f: FTPFile, path: Option[Path] = None): FtpResource =
     FtpResource(
-      path.foldLeft(Path.of(f.getName))((a, b) => b.resolve(a)),
+      path.foldLeft(Paths.get(f.getName))((a, b) => b.resolve(a)),
       f.getSize,
       f.getTimestamp.toInstant(),
       getPosixFilePermissions(f),
@@ -55,7 +55,7 @@ object FtpResource {
 
   def fromResource(file: RemoteResourceInfo): FtpResource =
     FtpResource(
-      Path.of(file.getPath),
+      Paths.get(file.getPath),
       file.getAttributes.getSize,
       Instant.ofEpochSecond(file.getAttributes.getMtime),
       posixFilePermissions(file.getAttributes),

--- a/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/FtpResource.scala
@@ -23,6 +23,7 @@ import net.schmizz.sshj.sftp.{ FileAttributes, RemoteResourceInfo }
 import net.schmizz.sshj.xfer.FilePermission._
 import org.apache.commons.net.ftp.FTPFile
 import scala.jdk.CollectionConverters._
+import java.nio.file.Path
 
 /**
  * Represent a file / directory / symbolic link on a ftp server
@@ -34,7 +35,7 @@ import scala.jdk.CollectionConverters._
  * @param isDirectory boolean flag: 'true' if it is a directory, 'false' if it is a file. In some situation we cannot determine the type of the resource
  */
 final case class FtpResource(
-  path: String,
+  path: Path,
   size: Long,
   lastModified: Instant,
   permissions: Set[PosixFilePermission],
@@ -43,12 +44,9 @@ final case class FtpResource(
 
 object FtpResource {
 
-  def fromFtpFile(f: FTPFile, path: Option[String] = None): FtpResource =
+  def fromFtpFile(f: FTPFile, path: Option[Path] = None): FtpResource =
     FtpResource(
-      path.fold(f.getName) {
-        case "/" => s"/${f.getName}"
-        case p   => s"$p/${f.getName}"
-      },
+      path.foldLeft(Path.of(f.getName))(_.resolve(_)),
       f.getSize,
       f.getTimestamp.toInstant(),
       getPosixFilePermissions(f),
@@ -57,14 +55,14 @@ object FtpResource {
 
   def fromResource(file: RemoteResourceInfo): FtpResource =
     FtpResource(
-      file.getPath,
+      Path.of(file.getPath),
       file.getAttributes.getSize,
       Instant.ofEpochSecond(file.getAttributes.getMtime),
       posixFilePermissions(file.getAttributes),
       Some(file.isDirectory)
     )
 
-  def apply(path: String, attr: FileAttributes): FtpResource =
+  def apply(path: Path, attr: FileAttributes): FtpResource =
     FtpResource(path, attr.getSize, Instant.ofEpochSecond(attr.getMtime), posixFilePermissions(attr), None)
 
   private def getPosixFilePermissions(file: FTPFile) =

--- a/zio-ftp/src/main/scala/zio/ftp/SecureFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/SecureFtp.scala
@@ -29,7 +29,7 @@ import zio._
 
 import scala.jdk.CollectionConverters._
 import zio.ZIO.{ acquireRelease, attemptBlockingIO, fromAutoCloseable, scoped }
-import java.nio.file.Path
+import java.nio.file.{ Path, Paths }
 
 /**
  * Secure Ftp client wrapper
@@ -93,7 +93,7 @@ sealed abstract class SecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
       )
       .flatMap(ZStream.fromIterable(_))
       .flatMap { f =>
-        if (f.isDirectory) lsDescendant(Path.of(f.getPath))
+        if (f.isDirectory) lsDescendant(Paths.get(f.getPath))
         else ZStream.succeed(FtpResource.fromResource(f))
       }
 

--- a/zio-ftp/src/main/scala/zio/ftp/SecureFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/SecureFtp.scala
@@ -29,6 +29,7 @@ import zio._
 
 import scala.jdk.CollectionConverters._
 import zio.ZIO.{ acquireRelease, attemptBlockingIO, fromAutoCloseable, scoped }
+import java.nio.file.Path
 
 /**
  * Secure Ftp client wrapper
@@ -38,13 +39,13 @@ import zio.ZIO.{ acquireRelease, attemptBlockingIO, fromAutoCloseable, scoped }
  */
 sealed abstract class SecureFtp(unsafeClient: Client) extends FtpAccessors[Client] {
 
-  def stat(path: String): ZIO[Any, IOException, Option[FtpResource]] =
-    execute(c => Option(c.statExistence(path)).map(FtpResource(path, _)))
+  def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] =
+    execute(c => Option(c.statExistence(path.toString)).map(FtpResource(path, _)))
 
-  def readFile(path: String, chunkSize: Int, fileOffset: Long): ZStream[Any, IOException, Byte] =
+  def readFile(path: Path, chunkSize: Int, fileOffset: Long): ZStream[Any, IOException, Byte] =
     for {
       remoteFile             <- ZStream.fromZIO(
-                                  execute(_.open(path, util.EnumSet.of(OpenMode.READ)))
+                                  execute(_.open(path.toString, util.EnumSet.of(OpenMode.READ)))
                                 )
 
       is: java.io.InputStream = new remoteFile.ReadAheadRemoteFileInputStream(64, fileOffset) {
@@ -57,19 +58,19 @@ sealed abstract class SecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
       input <- ZStream.fromInputStream(is, chunkSize)
     } yield input
 
-  def rm(path: String): ZIO[Any, IOException, Unit] =
-    execute(_.rm(path))
+  def rm(path: Path): ZIO[Any, IOException, Unit] =
+    execute(_.rm(path.toString))
 
-  def rmdir(path: String): ZIO[Any, IOException, Unit] =
-    execute(_.rmdir(path))
+  def rmdir(path: Path): ZIO[Any, IOException, Unit] =
+    execute(_.rmdir(path.toString))
 
-  def mkdir(path: String): ZIO[Any, IOException, Unit] =
-    execute(_.mkdirs(path))
+  def mkdir(path: Path): ZIO[Any, IOException, Unit] =
+    execute(_.mkdirs(path.toString))
 
-  def ls(path: String): ZStream[Any, IOException, FtpResource] =
+  def ls(path: Path): ZStream[Any, IOException, FtpResource] =
     ZStream
       .fromZIO(
-        execute(_.ls(path).asScala)
+        execute(_.ls(path.toString).asScala)
           .catchSome {
             case ex: SFTPException if ex.getStatusCode == Response.StatusCode.NO_SUCH_FILE =>
               ZIO.succeed(scala.collection.mutable.Buffer.empty[RemoteResourceInfo])
@@ -78,13 +79,13 @@ sealed abstract class SecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
       .flatMap(ZStream.fromIterable(_))
       .map(FtpResource.fromResource)
 
-  def rename(oldPath: String, newPath: String): ZIO[Any, IOException, Unit] =
-    execute(_.rename(oldPath, newPath))
+  def rename(oldPath: Path, newPath: Path): ZIO[Any, IOException, Unit] =
+    execute(_.rename(oldPath.toString, newPath.toString))
 
-  def lsDescendant(path: String): ZStream[Any, IOException, FtpResource] =
+  def lsDescendant(path: Path): ZStream[Any, IOException, FtpResource] =
     ZStream
       .fromZIO(
-        execute(_.ls(path).asScala)
+        execute(_.ls(path.toString).asScala)
           .catchSome {
             case ex: SFTPException if ex.getStatusCode == Response.StatusCode.NO_SUCH_FILE =>
               ZIO.succeed(scala.collection.mutable.Buffer.empty[RemoteResourceInfo])
@@ -92,13 +93,13 @@ sealed abstract class SecureFtp(unsafeClient: Client) extends FtpAccessors[Clien
       )
       .flatMap(ZStream.fromIterable(_))
       .flatMap { f =>
-        if (f.isDirectory) lsDescendant(f.getPath)
+        if (f.isDirectory) lsDescendant(Path.of(f.getPath))
         else ZStream.succeed(FtpResource.fromResource(f))
       }
 
-  def upload[R](path: String, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit] =
+  def upload[R](path: Path, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit] =
     for {
-      remoteFile <- execute(_.open(path, util.EnumSet.of(OpenMode.WRITE, OpenMode.CREAT)))
+      remoteFile <- execute(_.open(path.toString, util.EnumSet.of(OpenMode.WRITE, OpenMode.CREAT)))
       _          <- scoped[R] {
                       fromAutoCloseable(ZIO.succeed(new remoteFile.RemoteFileOutputStream() {
                         override def close(): Unit =

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -34,7 +34,7 @@ object TestFtp {
       override def execute[T](f: Unit => T): ZIO[Any, IOException, T] = ZIO.succeed(f((): Unit))
 
       override def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] = {
-        val p = root.resolve(path)
+        val p = inRoot(path)
         ZIO
           .attempt(
             Files

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -21,7 +21,7 @@ import java.nio.file.NoSuchFileException
 import java.nio.file.attribute.PosixFilePermission
 import scala.jdk.CollectionConverters._
 
-import java.nio.file.Path
+import java.nio.file.{ Path, Paths }
 import java.nio.file.Files
 import zio.stream.{ ZSink, ZStream }
 import zio.{ Cause, ZIO }
@@ -30,7 +30,7 @@ object TestFtp {
 
   def create(root: Path): FtpAccessors[Unit] =
     new FtpAccessors[Unit] {
-      def inRoot(p: Path)                                             = root.resolve(Path.of("/").relativize(p))
+      def inRoot(p: Path)                                             = root.resolve(Paths.get("/").relativize(p))
       override def execute[T](f: Unit => T): ZIO[Any, IOException, T] = ZIO.succeed(f((): Unit))
 
       override def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] = {
@@ -107,7 +107,7 @@ object TestFtp {
           isDir        <- ZIO.attempt(Files.isDirectory(p)).map(Some(_))
           lastModified <- ZIO.attempt(Files.getLastModifiedTime(p)).map(_.toInstant())
           size         <- ZIO.attempt(Files.size(p))
-        } yield FtpResource(Path.of("/").resolve(root.relativize(p)), size, lastModified, permissions, isDir))
+        } yield FtpResource(Paths.get("/").resolve(root.relativize(p)), size, lastModified, permissions, isDir))
           .mapError(new IOException(_))
 
       override def lsDescendant(path: Path): ZStream[Any, IOException, FtpResource] =

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -19,22 +19,26 @@ package zio.ftp
 import java.io.{ FileOutputStream, IOException }
 import java.nio.file.NoSuchFileException
 import java.nio.file.attribute.PosixFilePermission
+import scala.jdk.CollectionConverters._
 
-import zio.nio.file.{ Path => ZPath }
-import zio.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Files
 import zio.stream.{ ZSink, ZStream }
 import zio.{ Cause, ZIO }
 
 object TestFtp {
 
-  def create(root: ZPath): FtpAccessors[Unit] =
+  def create(root: Path): FtpAccessors[Unit] =
     new FtpAccessors[Unit] {
       override def execute[T](f: Unit => T): ZIO[Any, IOException, T] = ZIO.succeed(f((): Unit))
 
-      override def stat(path: String): ZIO[Any, IOException, Option[FtpResource]] = {
-        val p = root / ZPath(path).elements.mkString("/")
-        Files
-          .exists(p)
+      override def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] = {
+        val p = root.resolve(path)
+        ZIO
+          .attempt(
+            Files
+              .exists(p)
+          )
           .flatMap {
             case true  => get(p).map(Option(_))
             case false => ZIO.succeed(Option.empty[FtpResource])
@@ -42,54 +46,77 @@ object TestFtp {
           .refineToOrDie[IOException]
       }
 
-      override def readFile(path: String, chunkSize: Int, fileOffset: Long): ZStream[Any, IOException, Byte] =
-        ZStream
-          .fromZIO(Files.readAllBytes(root / ZPath(path).elements.mkString("/")))
+      override def readFile(path: Path, chunkSize: Int, fileOffset: Long): ZStream[Any, IOException, Byte] = {
+        val a: ZStream[Any, IOException, Byte] = ZStream
+          .fromInputStreamScoped(ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(Files.newInputStream(root.resolve(path)))))
+        a
           .catchAll {
             case _: NoSuchFileException => ZStream.fail(InvalidPathError(s"File does not exist $path"))
             case err                    => ZStream.fail(err)
           }
-          .flatMap(ZStream.fromChunk(_))
           .drop(fileOffset.toInt)
+      }
 
-      override def rm(path: String): ZIO[Any, IOException, Unit] =
-        Files
-          .delete(root / ZPath(path).elements.mkString("/"))
+      override def rm(path: Path): ZIO[Any, IOException, Unit] =
+        ZIO
+          .attemptBlockingIO(
+            Files
+              .delete(root.resolve(path))
+          )
           .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot delete : $path", err)))
 
-      override def rmdir(path: String): ZIO[Any, IOException, Unit] =
+      override def rmdir(path: Path): ZIO[Any, IOException, Unit] =
         rm(path)
 
-      override def mkdir(path: String) = // : ZIO[Any, IOException, Unit] =
-        Files
-          .createDirectories(root / ZPath(path).elements.mkString("/"))
+      override def mkdir(path: Path): ZIO[Any, IOException, Unit] =
+        ZIO
+          .attemptBlockingIO(
+            Files
+              .createDirectories(root.resolve(path))
+          )
           .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot create directory : $path", err)))
+          .unit
 
-      override def ls(path: String): ZStream[Any, IOException, FtpResource] =
-        Files
-          .list(root / ZPath(path).elements.mkString("/"))
+      override def ls(path: Path): ZStream[Any, IOException, FtpResource] =
+        ZStream
+          .fromJavaStreamScoped[Any, Path](
+            ZIO.fromAutoCloseable(
+              ZIO.attemptBlockingIO(
+                Files
+                  .list(root.resolve(path))
+              )
+            )
+          )
           .catchAll {
             case _: NoSuchFileException => ZStream.empty
             case err                    => ZStream.fail(new IOException(err))
           }
           .mapZIO(get)
 
-      private def get(p: ZPath): ZIO[Any, IOException, FtpResource] =
+      private def get(p: Path): ZIO[Any, IOException, FtpResource] =
         (for {
-          permissions  <- Files.getPosixFilePermissions(p).mapErrorCause(_.untraced).catchSomeCause {
-                            //Windows don't support this operations
-                            case Cause.Die(_: UnsupportedOperationException, _) =>
-                              ZIO.succeed(Set.empty[PosixFilePermission])
-                          }
-          isDir        <- Files.isDirectory(p).map(Some(_))
-          lastModified <- Files.getLastModifiedTime(p).map(_.toInstant())
-          size         <- Files.size(p)
-        } yield FtpResource(root.relativize(p).elements.mkString("/", "/", ""), size, lastModified, permissions, isDir))
+          permissions  <-
+            ZIO.attempt(Files.getPosixFilePermissions(p).asScala.toSet).mapErrorCause(_.untraced).catchSomeCause {
+              //Windows don't support this operation
+              case Cause.Die(_: UnsupportedOperationException, _) =>
+                ZIO.succeed(Set.empty[PosixFilePermission])
+            }
+          isDir        <- ZIO.attempt(Files.isDirectory(p)).map(Some(_))
+          lastModified <- ZIO.attempt(Files.getLastModifiedTime(p)).map(_.toInstant())
+          size         <- ZIO.attempt(Files.size(p))
+        } yield FtpResource(root.relativize(p), size, lastModified, permissions, isDir))
           .mapError(new IOException(_))
 
-      override def lsDescendant(path: String): ZStream[Any, IOException, FtpResource] =
-        Files
-          .find(root / ZPath(path).elements.mkString("/"))((_, attr) => attr.isRegularFile)
+      override def lsDescendant(path: Path): ZStream[Any, IOException, FtpResource] =
+        ZStream
+          .fromJavaStreamScoped[Any, Path](
+            ZIO.fromAutoCloseable(
+              ZIO.attempt(
+                Files
+                  .find(root.resolve(path), Int.MaxValue, (_, attr) => attr.isRegularFile)
+              )
+            )
+          )
           .catchAll {
             case _: NoSuchFileException => ZStream.empty
             case err                    => ZStream.fail(new IOException(err))
@@ -97,10 +124,10 @@ object TestFtp {
           .mapZIO(get)
 
       override def upload[R](
-        path: String,
+        path: Path,
         source: ZStream[R, Throwable, Byte]
       ): ZIO[R, IOException, Unit] = {
-        val file = (root / ZPath(path).elements.mkString("/")).toFile
+        val file = (root.resolve(path)).toFile
 
         ZIO.scoped[R] {
           ZIO
@@ -115,9 +142,12 @@ object TestFtp {
         }
       }
 
-      override def rename(oldPath: String, newPath: String): ZIO[Any, IOException, Unit] =
-        Files
-          .move(root / ZPath(oldPath).elements.mkString("/"), root / ZPath(newPath).elements.mkString("/"))
+      override def rename(oldPath: Path, newPath: Path): ZIO[Any, IOException, Unit] =
+        ZIO
+          .attempt(
+            Files
+              .move(root.resolve(oldPath), root.resolve(newPath)): Unit
+          )
           .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot rename $oldPath to $newPath", err)))
     }
 }

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -30,6 +30,7 @@ object TestFtp {
 
   def create(root: Path): FtpAccessors[Unit] =
     new FtpAccessors[Unit] {
+      def inRoot(p: Path) = root.resolve(Path.of("/").relativize(p))
       override def execute[T](f: Unit => T): ZIO[Any, IOException, T] = ZIO.succeed(f((): Unit))
 
       override def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] = {
@@ -48,7 +49,7 @@ object TestFtp {
 
       override def readFile(path: Path, chunkSize: Int, fileOffset: Long): ZStream[Any, IOException, Byte] = {
         val a: ZStream[Any, IOException, Byte] = ZStream
-          .fromInputStreamScoped(ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(Files.newInputStream(root.resolve(path)))))
+          .fromInputStreamScoped(ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(Files.newInputStream(inRoot(path)))))
         a
           .catchAll {
             case _: NoSuchFileException => ZStream.fail(InvalidPathError(s"File does not exist $path"))
@@ -61,7 +62,7 @@ object TestFtp {
         ZIO
           .attemptBlockingIO(
             Files
-              .delete(root.resolve(path))
+              .delete(inRoot(path))
           )
           .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot delete : $path", err)))
 
@@ -72,7 +73,7 @@ object TestFtp {
         ZIO
           .attemptBlockingIO(
             Files
-              .createDirectories(root.resolve(path))
+              .createDirectories(inRoot(path))
           )
           .catchAll[Any, IOException, Path](err =>
             ZIO.fail(new IOException(s"Path is invalid. Cannot create directory : $path", err))
@@ -85,7 +86,7 @@ object TestFtp {
             ZIO.fromAutoCloseable(
               ZIO.attemptBlockingIO(
                 Files
-                  .list(root.resolve(path))
+                  .list(inRoot(path))
               )
             )
           )
@@ -106,7 +107,7 @@ object TestFtp {
           isDir        <- ZIO.attempt(Files.isDirectory(p)).map(Some(_))
           lastModified <- ZIO.attempt(Files.getLastModifiedTime(p)).map(_.toInstant())
           size         <- ZIO.attempt(Files.size(p))
-        } yield FtpResource(root.relativize(p), size, lastModified, permissions, isDir))
+        } yield FtpResource(Path.of("/").resolve(root.relativize(p)), size, lastModified, permissions, isDir))
           .mapError(new IOException(_))
 
       override def lsDescendant(path: Path): ZStream[Any, IOException, FtpResource] =
@@ -115,7 +116,7 @@ object TestFtp {
             ZIO.fromAutoCloseable(
               ZIO.attempt(
                 Files
-                  .find(root.resolve(path), Int.MaxValue, (_, attr) => attr.isRegularFile)
+                  .find(inRoot(path), Int.MaxValue, (_, attr) => attr.isRegularFile)
               )
             )
           )
@@ -129,7 +130,7 @@ object TestFtp {
         path: Path,
         source: ZStream[R, Throwable, Byte]
       ): ZIO[R, IOException, Unit] = {
-        val file = (root.resolve(path)).toFile
+        val file = (inRoot(path)).toFile
 
         ZIO.scoped[R] {
           ZIO
@@ -147,7 +148,7 @@ object TestFtp {
       override def rename(oldPath: Path, newPath: Path): ZIO[Any, IOException, Unit] =
         ZIO
           .attempt {
-            Files.move(root.resolve(oldPath), root.resolve(newPath))
+            Files.move(inRoot(oldPath), inRoot(newPath))
             ()
           }
           .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot rename $oldPath to $newPath", err)))

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -30,7 +30,7 @@ object TestFtp {
 
   def create(root: Path): FtpAccessors[Unit] =
     new FtpAccessors[Unit] {
-      def inRoot(p: Path) = root.resolve(Path.of("/").relativize(p))
+      def inRoot(p: Path)                                             = root.resolve(Path.of("/").relativize(p))
       override def execute[T](f: Unit => T): ZIO[Any, IOException, T] = ZIO.succeed(f((): Unit))
 
       override def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] = {

--- a/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/TestFtp.scala
@@ -74,7 +74,9 @@ object TestFtp {
             Files
               .createDirectories(root.resolve(path))
           )
-          .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot create directory : $path", err)))
+          .catchAll[Any, IOException, Path](err =>
+            ZIO.fail(new IOException(s"Path is invalid. Cannot create directory : $path", err))
+          )
           .unit
 
       override def ls(path: Path): ZStream[Any, IOException, FtpResource] =
@@ -144,10 +146,10 @@ object TestFtp {
 
       override def rename(oldPath: Path, newPath: Path): ZIO[Any, IOException, Unit] =
         ZIO
-          .attempt(
-            Files
-              .move(root.resolve(oldPath), root.resolve(newPath)): Unit
-          )
+          .attempt {
+            Files.move(root.resolve(oldPath), root.resolve(newPath))
+            ()
+          }
           .catchAll(err => ZIO.fail(new IOException(s"Path is invalid. Cannot rename $oldPath to $newPath", err)))
     }
 }

--- a/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/UnsecureFtp.scala
@@ -21,6 +21,7 @@ import zio.ftp.UnsecureFtp.Client
 import zio.stream.ZStream
 import zio.{ Ref, Scope, UIO, ZIO }
 import zio.ZIO.{ acquireRelease, attemptBlockingIO }
+import java.nio.file.Path
 
 /**
  * Unsecure Ftp client wrapper
@@ -30,10 +31,10 @@ import zio.ZIO.{ acquireRelease, attemptBlockingIO }
  */
 sealed abstract class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Client] {
 
-  def stat(path: String): ZIO[Any, IOException, Option[FtpResource]] =
-    execute(c => Option(c.mlistFile(path))).map(_.map(FtpResource.fromFtpFile(_)))
+  def stat(path: Path): ZIO[Any, IOException, Option[FtpResource]] =
+    execute(c => Option(c.mlistFile(path.toString))).map(_.map(FtpResource.fromFtpFile(_)))
 
-  def readFile(path: String, chunkSize: Int = 2048, fileOffset: Long): ZStream[Any, IOException, Byte] = {
+  def readFile(path: Path, chunkSize: Int = 2048, fileOffset: Long): ZStream[Any, IOException, Byte] = {
     def error(cause: Option[Exception] = None): Left[FileTransferIncompleteError, Unit] =
       Left(
         FileTransferIncompleteError(
@@ -60,7 +61,8 @@ sealed abstract class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Cli
       }
 
     val inputStream =
-      execute(c => Option(c.retrieveFileStream(path))).someOrFail(InvalidPathError(s"File does not exist $path"))
+      execute(c => Option(c.retrieveFileStream(path.toString)))
+        .someOrFail(InvalidPathError(s"File does not exist $path"))
 
     ZStream.unwrap {
       for {
@@ -72,52 +74,51 @@ sealed abstract class UnsecureFtp(unsafeClient: Client) extends FtpAccessors[Cli
     }
   }
 
-  def rm(path: String): ZIO[Any, IOException, Unit] =
-    execute(_.deleteFile(path))
+  def rm(path: Path): ZIO[Any, IOException, Unit] =
+    execute(_.deleteFile(path.toString))
       .filterOrFail(identity)(InvalidPathError(s"Path is invalid. Cannot delete file : $path"))
       .unit
 
-  def rmdir(path: String): ZIO[Any, IOException, Unit] =
-    execute(_.removeDirectory(path))
+  def rmdir(path: Path): ZIO[Any, IOException, Unit] =
+    execute(_.removeDirectory(path.toString))
       .filterOrFail(identity)(InvalidPathError(s"Path is invalid. Cannot delete directory : $path"))
       .unit
 
-  def mkdir(path: String): ZIO[Any, IOException, Unit] =
-    execute(_.makeDirectory(path))
+  def mkdir(path: Path): ZIO[Any, IOException, Unit] =
+    execute(_.makeDirectory(path.toString))
       .filterOrFail(identity)(InvalidPathError(s"Path is invalid. Cannot create directory : $path"))
       .unit
 
-  def ls(path: String): ZStream[Any, IOException, FtpResource] =
+  def ls(path: Path): ZStream[Any, IOException, FtpResource] =
     ZStream
-      .fromZIO(execute(_.listFiles(path).toList))
+      .fromZIO(execute(_.listFiles(path.toString).toList))
       .flatMap(ZStream.fromIterable(_))
       .map(FtpResource.fromFtpFile(_, Some(path)))
 
-  def lsDescendant(path: String): ZStream[Any, IOException, FtpResource] =
+  def lsDescendant(path: Path): ZStream[Any, IOException, FtpResource] =
     ZStream
-      .fromZIO(execute(_.listFiles(path).toList))
+      .fromZIO(execute(_.listFiles(path.toString).toList))
       .flatMap(ZStream.fromIterable(_))
       .flatMap { f =>
-        if (f.isDirectory) {
-          val dirPath = Option(path).filter(_.endsWith("/")).fold(s"$path/${f.getName}")(p => s"$p${f.getName}")
-          lsDescendant(dirPath)
-        } else
+        if (f.isDirectory)
+          lsDescendant(path.resolve(f.getName()))
+        else
           ZStream(FtpResource.fromFtpFile(f, Some(path)))
       }
 
-  def upload[R](path: String, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit] =
+  def upload[R](path: Path, source: ZStream[R, Throwable, Byte]): ZIO[R, IOException, Unit] =
     ZIO.scoped[R] {
       source.toInputStream
         .mapError(new IOException(_))
         .flatMap(is =>
-          execute(_.storeFile(path, is))
+          execute(_.storeFile(path.toString, is))
             .filterOrFail(identity)(InvalidPathError(s"Path is invalid. Cannot upload data to : $path"))
             .unit
         )
     }
 
-  def rename(oldPath: String, newPath: String): ZIO[Any, IOException, Unit] =
-    execute(_.rename(oldPath, newPath))
+  def rename(oldPath: Path, newPath: Path): ZIO[Any, IOException, Unit] =
+    execute(_.rename(oldPath.toString, newPath.toString))
       .filterOrFail(identity)(InvalidPathError(s"Path is invalid. Cannot rename $oldPath to $newPath"))
       .unit
 

--- a/zio-ftp/src/main/scala/zio/ftp/package.scala
+++ b/zio-ftp/src/main/scala/zio/ftp/package.scala
@@ -18,8 +18,8 @@ package zio
 
 import java.io.IOException
 
-import zio.nio.file.{ Path => ZPath }
 import zio.stream.ZStream
+import java.nio.file.Path
 
 package object ftp {
   //Alias Unsecure Ftp dependency
@@ -34,26 +34,26 @@ package object ftp {
     def execute[T](f: UnsecureFtp.Client => T): ZIO[Ftp, IOException, T] =
       ZIO.serviceWithZIO(_.execute(f))
 
-    def stat(path: String): ZIO[Ftp, IOException, Option[FtpResource]] =
+    def stat(path: Path): ZIO[Ftp, IOException, Option[FtpResource]] =
       ZIO.serviceWithZIO(_.stat(path))
 
-    def rm(path: String): ZIO[Ftp, IOException, Unit] =
+    def rm(path: Path): ZIO[Ftp, IOException, Unit] =
       ZIO.serviceWithZIO(_.rm(path))
 
-    def rmdir(path: String): ZIO[Ftp, IOException, Unit] =
+    def rmdir(path: Path): ZIO[Ftp, IOException, Unit] =
       ZIO.serviceWithZIO(_.rmdir(path))
 
-    def mkdir(path: String): ZIO[Ftp, IOException, Unit] =
+    def mkdir(path: Path): ZIO[Ftp, IOException, Unit] =
       ZIO.serviceWithZIO(_.mkdir(path))
 
-    def ls(path: String): ZStream[Ftp, IOException, FtpResource] =
+    def ls(path: Path): ZStream[Ftp, IOException, FtpResource] =
       ZStream.serviceWithStream(_.ls(path))
 
-    def lsDescendant(path: String): ZStream[Ftp, IOException, FtpResource] =
+    def lsDescendant(path: Path): ZStream[Ftp, IOException, FtpResource] =
       ZStream.serviceWithStream(_.lsDescendant(path))
 
     def upload[R](
-      path: String,
+      path: Path,
       source: ZStream[R, Throwable, Byte]
     ): ZIO[R with Ftp, IOException, Unit] =
       for {
@@ -61,10 +61,10 @@ package object ftp {
         _   <- ftp.upload(path, source)
       } yield ()
 
-    def readFile(path: String, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[Ftp, IOException, Byte] =
+    def readFile(path: Path, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[Ftp, IOException, Byte] =
       ZStream.serviceWithStream(_.readFile(path, chunkSize, fileOffset))
 
-    def rename(oldPath: String, newPath: String): ZIO[Ftp, Exception, Unit] =
+    def rename(oldPath: Path, newPath: Path): ZIO[Ftp, Exception, Unit] =
       ZIO.serviceWithZIO(_.rename(oldPath, newPath))
   }
 
@@ -73,26 +73,26 @@ package object ftp {
     def execute[T](f: SecureFtp.Client => T): ZIO[SFtp, IOException, T] =
       ZIO.serviceWithZIO(_.execute(f))
 
-    def stat(path: String): ZIO[SFtp, IOException, Option[FtpResource]] =
+    def stat(path: Path): ZIO[SFtp, IOException, Option[FtpResource]] =
       ZIO.serviceWithZIO(_.stat(path))
 
-    def rm(path: String): ZIO[SFtp, IOException, Unit] =
+    def rm(path: Path): ZIO[SFtp, IOException, Unit] =
       ZIO.serviceWithZIO(_.rm(path))
 
-    def rmdir(path: String): ZIO[SFtp, IOException, Unit] =
+    def rmdir(path: Path): ZIO[SFtp, IOException, Unit] =
       ZIO.serviceWithZIO(_.rmdir(path))
 
-    def mkdir(path: String): ZIO[SFtp, IOException, Unit] =
+    def mkdir(path: Path): ZIO[SFtp, IOException, Unit] =
       ZIO.serviceWithZIO(_.mkdir(path))
 
-    def ls(path: String): ZStream[SFtp, IOException, FtpResource] =
+    def ls(path: Path): ZStream[SFtp, IOException, FtpResource] =
       ZStream.serviceWithStream(_.ls(path))
 
-    def lsDescendant(path: String): ZStream[SFtp, IOException, FtpResource] =
+    def lsDescendant(path: Path): ZStream[SFtp, IOException, FtpResource] =
       ZStream.serviceWithStream(_.lsDescendant(path))
 
     def upload[R](
-      path: String,
+      path: Path,
       source: ZStream[R, Throwable, Byte]
     ): ZIO[SFtp with R, IOException, Unit] =
       for {
@@ -100,10 +100,10 @@ package object ftp {
         _   <- ftp.upload(path, source)
       } yield ()
 
-    def readFile(path: String, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[SFtp, IOException, Byte] =
+    def readFile(path: Path, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[SFtp, IOException, Byte] =
       ZStream.serviceWithStream(_.readFile(path, chunkSize, fileOffset))
 
-    def rename(oldPath: String, newPath: String): ZIO[SFtp, Exception, Unit] =
+    def rename(oldPath: Path, newPath: Path): ZIO[SFtp, Exception, Unit] =
       ZIO.serviceWithZIO(_.rename(oldPath, newPath))
   }
 
@@ -112,26 +112,26 @@ package object ftp {
     def execute[T](f: Unit => T): ZIO[StubFtp, IOException, T] =
       ZIO.serviceWithZIO(_.execute(f))
 
-    def stat(path: String): ZIO[StubFtp, IOException, Option[FtpResource]] =
+    def stat(path: Path): ZIO[StubFtp, IOException, Option[FtpResource]] =
       ZIO.serviceWithZIO(_.stat(path))
 
-    def rm(path: String): ZIO[StubFtp, IOException, Unit] =
+    def rm(path: Path): ZIO[StubFtp, IOException, Unit] =
       ZIO.serviceWithZIO(_.rm(path))
 
-    def rmdir(path: String): ZIO[StubFtp, IOException, Unit] =
+    def rmdir(path: Path): ZIO[StubFtp, IOException, Unit] =
       ZIO.serviceWithZIO(_.rmdir(path))
 
-    def mkdir(path: String): ZIO[StubFtp, IOException, Unit] =
+    def mkdir(path: Path): ZIO[StubFtp, IOException, Unit] =
       ZIO.serviceWithZIO(_.mkdir(path))
 
-    def ls(path: String): ZStream[StubFtp, IOException, FtpResource] =
+    def ls(path: Path): ZStream[StubFtp, IOException, FtpResource] =
       ZStream.serviceWithStream(_.ls(path))
 
-    def lsDescendant(path: String): ZStream[StubFtp, IOException, FtpResource] =
+    def lsDescendant(path: Path): ZStream[StubFtp, IOException, FtpResource] =
       ZStream.serviceWithStream(_.lsDescendant(path))
 
     def upload[R](
-      path: String,
+      path: Path,
       source: ZStream[R, Throwable, Byte]
     ): ZIO[StubFtp with R, IOException, Unit] =
       for {
@@ -139,10 +139,10 @@ package object ftp {
         _   <- ftp.upload(path, source)
       } yield ()
 
-    def readFile(path: String, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[StubFtp, IOException, Byte] =
+    def readFile(path: Path, chunkSize: Int = 2048, fileOffset: Long = 0): ZStream[StubFtp, IOException, Byte] =
       ZStream.serviceWithStream(_.readFile(path, chunkSize, fileOffset))
 
-    def rename(oldPath: String, newPath: String): ZIO[StubFtp, Exception, Unit] =
+    def rename(oldPath: Path, newPath: Path): ZIO[StubFtp, Exception, Unit] =
       ZIO.serviceWithZIO(_.rename(oldPath, newPath))
   }
 
@@ -152,6 +152,6 @@ package object ftp {
   def secure(settings: SecureFtpSettings): ZLayer[Any, ConnectionError, SFtp] =
     ZLayer.scoped(SecureFtp.connect(settings))
 
-  def stub(path: ZPath): Layer[Any, StubFtp] =
+  def stub(path: Path): Layer[Any, StubFtp] =
     ZLayer.succeed(TestFtp.create(path))
 }

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -12,7 +12,6 @@ import java.net.{ InetSocketAddress, Proxy }
 import java.nio.file.{ Files, Paths }
 import java.time.{ Duration => JDuration }
 import scala.io.Source
-import scala.util.chaining._
 
 object Load
 
@@ -76,8 +75,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
         } yield assertTrue(
           files.map(_.path).toSet == Set(Paths.get("/notes.txt"), Paths.get("/dir1")) && files
             .find(_.path == Paths.get("/notes.txt"))
-            .is(_.some)
-            .pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 10000)
+            .exists(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 10000)
         )
       ),
       test("ls with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -77,7 +77,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
           files.map(_.path).toSet == Set(Paths.get("/notes.txt"), Paths.get("/dir1")) && files
             .find(_.path == Paths.get("/notes.txt"))
             .is(_.some)
-            .pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 1000)
+            .pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 10000)
         )
       ),
       test("ls with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -72,7 +72,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("ls")(
         for {
-          files <- ls(Path.of("/")).runCollect
+          files    <- ls(Path.of("/")).runCollect
           filetime <- ZIO.attempt(Files.getLastModifiedTime(Path.of("ftp-home/ftp/home/notes.txt")))
         } yield assertTrue(
           files.map(_.path).toSet == Set(Path.of("/notes.txt"), Path.of("/dir1")) && files

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -11,7 +11,6 @@ import zio.test._
 import java.net.{ InetSocketAddress, Proxy }
 import java.nio.file.{ Files, Paths }
 import java.time.{ Duration => JDuration }
-import java.nio.file.Path
 import scala.io.Source
 import scala.util.chaining._
 
@@ -72,57 +71,57 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("ls")(
         for {
-          files    <- ls(Path.of("/")).runCollect
-          filetime <- ZIO.attempt(Files.getLastModifiedTime(Path.of("ftp-home/ftp/home/notes.txt")))
+          files    <- ls(Paths.get("/")).runCollect
+          filetime <- ZIO.attempt(Files.getLastModifiedTime(Paths.get("ftp-home/ftp/home/notes.txt")))
         } yield assertTrue(
-          files.map(_.path).toSet == Set(Path.of("/notes.txt"), Path.of("/dir1")) && files
-            .find(_.path == Path.of("/notes.txt"))
+          files.map(_.path).toSet == Set(Paths.get("/notes.txt"), Paths.get("/dir1")) && files
+            .find(_.path == Paths.get("/notes.txt"))
             .is(_.some)
             .pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 1000)
         )
       ),
       test("ls with invalid directory")(
         for {
-          files <- ls(Path.of("/dont-exist")).runCollect
+          files <- ls(Paths.get("/dont-exist")).runCollect
         } yield assert(files.map(_.path))(hasSameElements(Nil))
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant(Path.of("/")).runCollect
+          files <- lsDescendant(Paths.get("/")).runCollect
         } yield assert(files.map(_.path.toString))(
           hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
         )
       ),
       test("ls descendant with invalid directory")(
         for {
-          files <- lsDescendant(Path.of("/dont-exist")).runCollect
+          files <- lsDescendant(Paths.get("/dont-exist")).runCollect
         } yield assert(files.map(_.path))(hasSameElements(Nil))
       ),
       test("stat file") {
         for {
-          file <- stat(Path.of("/dir1/users.csv"))
-        } yield assertTrue(file.get.path == Path.of("/dir1/users.csv")) &&
+          file <- stat(Paths.get("/dir1/users.csv"))
+        } yield assertTrue(file.get.path == Paths.get("/dir1/users.csv")) &&
           assertTrue(file.get.isDirectory.isEmpty)
       },
       test("stat directory") {
         for {
-          file <- stat(Path.of("/dir1"))
-        } yield assertTrue(file.get.path == Path.of("/dir1")) &&
+          file <- stat(Paths.get("/dir1"))
+        } yield assertTrue(file.get.path == Paths.get("/dir1")) &&
           assertTrue(file.get.isDirectory.isEmpty)
       },
       test("stat file does not exist") {
         for {
-          file <- stat(Path.of("/wrong-path.xml"))
+          file <- stat(Paths.get("/wrong-path.xml"))
         } yield assertTrue(file.isEmpty)
       },
       test("stat directory does not exist") {
         for {
-          file <- stat(Path.of("/wrong-path"))
+          file <- stat(Paths.get("/wrong-path"))
         } yield assertTrue(file.isEmpty)
       },
       test("readFile") {
         for {
-          content <- readFile(Path.of("/notes.txt"))
+          content <- readFile(Paths.get("/notes.txt"))
                        .via(utf8Decode)
                        .runCollect
         } yield assertTrue(
@@ -133,12 +132,12 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("readFile with offset") {
         for {
-          content <- readFile(Path.of("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
+          content <- readFile(Paths.get("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("this is a beautiful day"))
       },
       test("readFile does not exist") {
         for {
-          invalid <- readFile(Path.of("/invalid.txt"))
+          invalid <- readFile(Paths.get("/invalid.txt"))
                        .via(utf8Decode)
                        .runCollect
                        .foldCause(_.failureOption.map(_.getMessage).mkString, _.mkString)
@@ -147,12 +146,12 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("mkdir directory") {
         (for {
-          result <- mkdir(Path.of("/dir1/new-dir")).as(true)
+          result <- mkdir(Paths.get("/dir1/new-dir")).as(true)
         } yield assertTrue(result)) <* attempt(Files.delete(home.resolve("dir1/new-dir")))
       },
       test("mkdir fail when invalid path") {
         for {
-          failure <- mkdir(Path.of("/dir1/users.csv")).flip.map(_.getMessage)
+          failure <- mkdir(Paths.get("/dir1/users.csv")).flip.map(_.getMessage)
         } yield assert(failure)(containsString("/dir1/users.csv exists but is not a directory"))
       },
       test("rm valid path") {
@@ -160,13 +159,13 @@ object SecureFtpSpec extends ZIOSpecDefault {
         Files.createFile(path)
 
         for {
-          success   <- rm(Path.of("/dir1/to-delete.txt")).as(true)
+          success   <- rm(Paths.get("/dir1/to-delete.txt")).as(true)
           fileExist <- attempt(Files.notExists(path))
         } yield assertTrue(success && fileExist)
       },
       test("rm fail when invalid path") {
         for {
-          invalid <- rm(Path.of("/dont-exist")).flip.map(_.getMessage)
+          invalid <- rm(Paths.get("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "No such file")
       },
       test("rm directory") {
@@ -174,13 +173,13 @@ object SecureFtpSpec extends ZIOSpecDefault {
         Files.createDirectory(path)
 
         for {
-          r     <- rmdir(Path.of("/dir1/dir-to-delete")).as(true)
+          r     <- rmdir(Paths.get("/dir1/dir-to-delete")).as(true)
           exist <- attempt(Files.notExists(path))
         } yield assertTrue(r && exist)
       },
       test("rm fail invalid directory") {
         for {
-          r <- rmdir(Path.of("/dont-exist")).flip.map(_.getMessage)
+          r <- rmdir(Paths.get("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(r == "No such file")
       },
       test("upload a file") {
@@ -189,7 +188,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
 
         (
           for {
-            _      <- upload(Path.of("/dir1/hello-world.txt"), data)
+            _      <- upload(Paths.get("/dir1/hello-world.txt"), data)
             result <- acquireRelease(attemptBlockingIO(Source.fromFile(path.toFile)))(b =>
                         attemptBlockingIO(b.close()).ignore
                       ).map(_.mkString)
@@ -201,7 +200,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
         for {
-          failure <- upload(Path.of("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
+          failure <- upload(Paths.get("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
         } yield assertTrue(failure == "No such file")
       },
       test("call version() underlying client") {
@@ -216,7 +215,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
 
         (
           for {
-            success       <- rename(Path.of("/dir1/to-rename.txt"), Path.of("/dir1/to-rename-destination.txt")).as(true)
+            success       <- rename(Paths.get("/dir1/to-rename.txt"), Paths.get("/dir1/to-rename-destination.txt")).as(true)
             oldFileExists <- attempt(Files.exists(oldPath))
             newFileExists <- attempt(Files.exists(newPath))
           } yield assertTrue(success && !oldFileExists && newFileExists)
@@ -224,7 +223,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("rename fail when invalid path") {
         for {
-          invalid <- rename(Path.of("/dont-exist"), Path.of("dont-exist-destination")).flip.map(_.getMessage)
+          invalid <- rename(Paths.get("/dont-exist"), Paths.get("dont-exist-destination")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "No such file")
       }
     ).provideSomeLayerShared[Scope](secure(settings))

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -10,10 +10,10 @@ import zio.test._
 
 import java.net.{ InetSocketAddress, Proxy }
 import java.nio.file.{ Files, Paths }
-import java.time.Instant
 import java.time.{ Duration => JDuration }
 import java.nio.file.Path
 import scala.io.Source
+import scala.util.chaining._
 
 object Load
 
@@ -73,10 +73,12 @@ object SecureFtpSpec extends ZIOSpecDefault {
       test("ls")(
         for {
           files <- ls(Path.of("/")).runCollect
+          filetime <- ZIO.attempt(Files.getLastModifiedTime(Path.of("ftp-home/ftp/home/notes.txt")))
         } yield assertTrue(
           files.map(_.path).toSet == Set(Path.of("/notes.txt"), Path.of("/dir1")) && files
-            .find(_.path == "/notes.txt")
-            .exists(r => JDuration.between(r.lastModified, Instant.now()).abs.toMinutes < 10)
+            .find(_.path == Path.of("/notes.txt"))
+            .is(_.some)
+            .pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 1000)
         )
       ),
       test("ls with invalid directory")(
@@ -87,7 +89,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
       test("ls descendant")(
         for {
           files <- lsDescendant(Path.of("/")).runCollect
-        } yield assert(files.map(_.path))(
+        } yield assert(files.map(_.path.toString))(
           hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
         )
       ),

--- a/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/SecureFtpSpec.scala
@@ -10,9 +10,10 @@ import zio.test._
 
 import java.net.{ InetSocketAddress, Proxy }
 import java.nio.file.{ Files, Paths }
-import scala.io.Source
 import java.time.Instant
 import java.time.{ Duration => JDuration }
+import java.nio.file.Path
+import scala.io.Source
 
 object Load
 
@@ -71,55 +72,55 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("ls")(
         for {
-          files <- ls("/").runCollect
+          files <- ls(Path.of("/")).runCollect
         } yield assertTrue(
-          files.map(_.path).toSet == Set("/notes.txt", "/dir1") && files
+          files.map(_.path).toSet == Set(Path.of("/notes.txt"), Path.of("/dir1")) && files
             .find(_.path == "/notes.txt")
             .exists(r => JDuration.between(r.lastModified, Instant.now()).abs.toMinutes < 10)
         )
       ),
       test("ls with invalid directory")(
         for {
-          files <- ls("/dont-exist").runCollect
+          files <- ls(Path.of("/dont-exist")).runCollect
         } yield assert(files.map(_.path))(hasSameElements(Nil))
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant("/").runCollect
+          files <- lsDescendant(Path.of("/")).runCollect
         } yield assert(files.map(_.path))(
           hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
         )
       ),
       test("ls descendant with invalid directory")(
         for {
-          files <- lsDescendant("/dont-exist").runCollect
+          files <- lsDescendant(Path.of("/dont-exist")).runCollect
         } yield assert(files.map(_.path))(hasSameElements(Nil))
       ),
       test("stat file") {
         for {
-          file <- stat("/dir1/users.csv")
-        } yield assertTrue(file.get.path == "/dir1/users.csv") &&
+          file <- stat(Path.of("/dir1/users.csv"))
+        } yield assertTrue(file.get.path == Path.of("/dir1/users.csv")) &&
           assertTrue(file.get.isDirectory.isEmpty)
       },
       test("stat directory") {
         for {
-          file <- stat("/dir1")
-        } yield assertTrue(file.get.path == "/dir1") &&
+          file <- stat(Path.of("/dir1"))
+        } yield assertTrue(file.get.path == Path.of("/dir1")) &&
           assertTrue(file.get.isDirectory.isEmpty)
       },
       test("stat file does not exist") {
         for {
-          file <- stat("/wrong-path.xml")
+          file <- stat(Path.of("/wrong-path.xml"))
         } yield assertTrue(file.isEmpty)
       },
       test("stat directory does not exist") {
         for {
-          file <- stat("/wrong-path")
+          file <- stat(Path.of("/wrong-path"))
         } yield assertTrue(file.isEmpty)
       },
       test("readFile") {
         for {
-          content <- readFile("/notes.txt")
+          content <- readFile(Path.of("/notes.txt"))
                        .via(utf8Decode)
                        .runCollect
         } yield assertTrue(
@@ -130,12 +131,12 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("readFile with offset") {
         for {
-          content <- readFile("/notes.txt", fileOffset = 16).via(utf8Decode).runCollect
+          content <- readFile(Path.of("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("this is a beautiful day"))
       },
       test("readFile does not exist") {
         for {
-          invalid <- readFile("/invalid.txt")
+          invalid <- readFile(Path.of("/invalid.txt"))
                        .via(utf8Decode)
                        .runCollect
                        .foldCause(_.failureOption.map(_.getMessage).mkString, _.mkString)
@@ -144,12 +145,12 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("mkdir directory") {
         (for {
-          result <- mkdir("/dir1/new-dir").as(true)
+          result <- mkdir(Path.of("/dir1/new-dir")).as(true)
         } yield assertTrue(result)) <* attempt(Files.delete(home.resolve("dir1/new-dir")))
       },
       test("mkdir fail when invalid path") {
         for {
-          failure <- mkdir("/dir1/users.csv").flip.map(_.getMessage)
+          failure <- mkdir(Path.of("/dir1/users.csv")).flip.map(_.getMessage)
         } yield assert(failure)(containsString("/dir1/users.csv exists but is not a directory"))
       },
       test("rm valid path") {
@@ -157,13 +158,13 @@ object SecureFtpSpec extends ZIOSpecDefault {
         Files.createFile(path)
 
         for {
-          success   <- rm("/dir1/to-delete.txt").as(true)
+          success   <- rm(Path.of("/dir1/to-delete.txt")).as(true)
           fileExist <- attempt(Files.notExists(path))
         } yield assertTrue(success && fileExist)
       },
       test("rm fail when invalid path") {
         for {
-          invalid <- rm("/dont-exist").flip.map(_.getMessage)
+          invalid <- rm(Path.of("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "No such file")
       },
       test("rm directory") {
@@ -171,13 +172,13 @@ object SecureFtpSpec extends ZIOSpecDefault {
         Files.createDirectory(path)
 
         for {
-          r     <- rmdir("/dir1/dir-to-delete").as(true)
+          r     <- rmdir(Path.of("/dir1/dir-to-delete")).as(true)
           exist <- attempt(Files.notExists(path))
         } yield assertTrue(r && exist)
       },
       test("rm fail invalid directory") {
         for {
-          r <- rmdir("/dont-exist").flip.map(_.getMessage)
+          r <- rmdir(Path.of("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(r == "No such file")
       },
       test("upload a file") {
@@ -186,7 +187,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
 
         (
           for {
-            _      <- upload("/dir1/hello-world.txt", data)
+            _      <- upload(Path.of("/dir1/hello-world.txt"), data)
             result <- acquireRelease(attemptBlockingIO(Source.fromFile(path.toFile)))(b =>
                         attemptBlockingIO(b.close()).ignore
                       ).map(_.mkString)
@@ -198,7 +199,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
         for {
-          failure <- upload("/dont-exist/hello-world.txt", data).flip.map(_.getMessage)
+          failure <- upload(Path.of("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
         } yield assertTrue(failure == "No such file")
       },
       test("call version() underlying client") {
@@ -213,7 +214,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
 
         (
           for {
-            success       <- rename("/dir1/to-rename.txt", "/dir1/to-rename-destination.txt").as(true)
+            success       <- rename(Path.of("/dir1/to-rename.txt"), Path.of("/dir1/to-rename-destination.txt")).as(true)
             oldFileExists <- attempt(Files.exists(oldPath))
             newFileExists <- attempt(Files.exists(newPath))
           } yield assertTrue(success && !oldFileExists && newFileExists)
@@ -221,7 +222,7 @@ object SecureFtpSpec extends ZIOSpecDefault {
       },
       test("rename fail when invalid path") {
         for {
-          invalid <- rename("/dont-exist", "dont-exist-destination").flip.map(_.getMessage)
+          invalid <- rename(Path.of("/dont-exist"), Path.of("dont-exist-destination")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "No such file")
       }
     ).provideSomeLayerShared[Scope](secure(settings))

--- a/zio-ftp/src/test/scala/zio/ftp/StubFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/StubFtpSpec.scala
@@ -29,9 +29,9 @@ object StubFtpSpec extends ZIOSpecDefault {
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
-        } yield assert(files.reverse)(
-          hasSameElements(List(Path.of("/notes.txt"), "/dir1/users.csv", "/dir1/console.dump"))
+          files <- lsDescendant(Path.of("/")).runFold(List.empty[String])((s, f) => f.path.toString +: s)
+        } yield assert(files)(
+          hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
         )
       ),
       test("ls descendant with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/StubFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/StubFtpSpec.scala
@@ -9,73 +9,73 @@ import zio.test._
 import zio.{ Chunk, Scope }
 
 import scala.io.Source
-import java.nio.file.{ Files, Path }
+import java.nio.file.{ Files, Path, Paths }
 import zio.ZIO
 
 object StubFtpSpec extends ZIOSpecDefault {
-  val home = Path.of("ftp-home/stub/home")
+  val home = Paths.get("ftp-home/stub/home")
 
   override def spec =
     suite("StubFtpSpec")(
       test("ls")(
         for {
-          files <- ls(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
-        } yield assert(files.reverse)(hasSameElements(List(Path.of("/notes.txt"), Path.of("/dir1"))))
+          files <- ls(Paths.get("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
+        } yield assert(files.reverse)(hasSameElements(List(Paths.get("/notes.txt"), Paths.get("/dir1"))))
       ),
       test("ls with invalid directory")(
         for {
-          files <- ls(Path.of("/dont-exist")).runFold(List.empty[Path])((s, f) => f.path +: s)
+          files <- ls(Paths.get("/dont-exist")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(hasSameElements(Nil))
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant(Path.of("/")).runFold(List.empty[String])((s, f) => f.path.toString +: s)
+          files <- lsDescendant(Paths.get("/")).runFold(List.empty[String])((s, f) => f.path.toString +: s)
         } yield assert(files)(
           hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
         )
       ),
       test("ls descendant with invalid directory")(
         for {
-          files <- lsDescendant(Path.of("/dont-exist")).runCollect
+          files <- lsDescendant(Paths.get("/dont-exist")).runCollect
         } yield assertTrue(files == Chunk.empty)
       ),
       test("stat directory") {
         for {
 
-          file <- stat(Path.of("/dir1"))
-        } yield assertTrue(file.get.path == Path.of("/dir1")) &&
+          file <- stat(Paths.get("/dir1"))
+        } yield assertTrue(file.get.path == Paths.get("/dir1")) &&
           assertTrue(file.get.isDirectory.get)
       },
       test("stat file") {
         for {
-          file <- stat(Path.of("/dir1/console.dump"))
-        } yield assertTrue(file.get.path == Path.of("/dir1/console.dump")) &&
+          file <- stat(Paths.get("/dir1/console.dump"))
+        } yield assertTrue(file.get.path == Paths.get("/dir1/console.dump")) &&
           assertTrue(!file.get.isDirectory.get)
       },
       test("stat file does not exist") {
         for {
-          file <- stat(Path.of("/wrong-path.xml"))
+          file <- stat(Paths.get("/wrong-path.xml"))
         } yield assertTrue(file.isEmpty)
       },
       test("stat directory does not exist") {
         for {
-          file <- stat(Path.of("/wrong-path"))
+          file <- stat(Paths.get("/wrong-path"))
         } yield assertTrue(file.isEmpty)
       },
       test("readFile") {
         for {
-          content <- readFile(Path.of("/notes.txt")).via(utf8Decode).runCollect
+          content <- readFile(Paths.get("/notes.txt")).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("""|Hello world !!!
                                                     |this is a beautiful day""".stripMargin))
       },
       test("readFile with offset") {
         for {
-          content <- readFile(Path.of("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
+          content <- readFile(Paths.get("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("this is a beautiful day"))
       },
       test("readFile does not exist") {
         for {
-          invalid <- readFile(Path.of("/invalid.txt"))
+          invalid <- readFile(Paths.get("/invalid.txt"))
                        .via(utf8Decode)
                        .runCollect
                        .flip
@@ -85,12 +85,12 @@ object StubFtpSpec extends ZIOSpecDefault {
       },
       test("mkdir directory") {
         (for {
-          result <- mkdir(Path.of("/new-dir")).as(true)
+          result <- mkdir(Paths.get("/new-dir")).as(true)
         } yield assertTrue(result)) <* ZIO.attempt(Files.delete(home.resolve("new-dir")))
       },
       test("mkdir fail when invalid path") {
         for {
-          failure <- mkdir(Path.of("/dir1/users.csv")).flip.map(_.getMessage)
+          failure <- mkdir(Paths.get("/dir1/users.csv")).flip.map(_.getMessage)
         } yield assert(failure)(containsString("Path is invalid. Cannot create directory : /dir1/users.csv"))
       },
       test("rm valid path") {
@@ -98,27 +98,27 @@ object StubFtpSpec extends ZIOSpecDefault {
 
         for {
           _       <- ZIO.attempt(Files.createFile(path))
-          success <- rm(Path.of("/to-delete.txt")).as(true)
+          success <- rm(Paths.get("/to-delete.txt")).as(true)
 
           fileExist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(success && fileExist)
       },
       test("rm fail when invalid path") {
         for {
-          invalid <- rm(Path.of("/dont-exist")).flip.map(_.getMessage)
+          invalid <- rm(Paths.get("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "Path is invalid. Cannot delete : /dont-exist")
       },
       test("rm directory") {
         val path = home.resolve("dir-to-delete")
         for {
           _     <- ZIO.attempt(Files.createDirectory(path))
-          r     <- rmdir(Path.of("/dir-to-delete")).as(true)
+          r     <- rmdir(Paths.get("/dir-to-delete")).as(true)
           exist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(r && exist)
       },
       test("rm fail invalid directory") {
         for {
-          r <- rmdir(Path.of("/dont-exist")).flip.map(_.getMessage)
+          r <- rmdir(Paths.get("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(r == "Path is invalid. Cannot delete : /dont-exist")
       },
       test("upload a file") {
@@ -126,7 +126,7 @@ object StubFtpSpec extends ZIOSpecDefault {
         val path = home.resolve("hello-world.txt")
 
         (for {
-          _      <- upload(Path.of("/hello-world.txt"), data)
+          _      <- upload(Paths.get("/hello-world.txt"), data)
           result <-
             acquireRelease(attemptBlockingIO(Source.fromFile(path.toFile)))(b => attemptBlockingIO(b.close()).ignore)
               .map(_.mkString)
@@ -137,7 +137,7 @@ object StubFtpSpec extends ZIOSpecDefault {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
         for {
-          failure <- upload(Path.of("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
+          failure <- upload(Paths.get("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
 
         } yield assertTrue(failure == "Path is invalid. Cannot upload data to : /dont-exist/hello-world.txt")
       },
@@ -147,7 +147,7 @@ object StubFtpSpec extends ZIOSpecDefault {
 
         (for {
           _       <- ZIO.attempt(Files.createFile(oldPath))
-          success <- rename(Path.of("/to-rename.txt"), Path.of("/to-rename-destination.txt")).as(true)
+          success <- rename(Paths.get("/to-rename.txt"), Paths.get("/to-rename-destination.txt")).as(true)
 
           oldFileExists <- ZIO.attempt(Files.exists(oldPath))
           newFileExists <- ZIO.attempt(Files.exists(newPath))
@@ -155,7 +155,8 @@ object StubFtpSpec extends ZIOSpecDefault {
       },
       test("rename a file fails when old path doesn't exist") {
         for {
-          failure <- rename(Path.of("/dont-exist.txt"), Path.of("/dont-exist-destination.txt")).flip.map(_.getMessage)
+          failure <-
+            rename(Paths.get("/dont-exist.txt"), Paths.get("/dont-exist-destination.txt")).flip.map(_.getMessage)
         } yield assertTrue(failure == "Path is invalid. Cannot rename /dont-exist.txt to /dont-exist-destination.txt")
       }
     ).provideSomeLayerShared[Scope](stub(home))

--- a/zio-ftp/src/test/scala/zio/ftp/StubFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/StubFtpSpec.scala
@@ -2,7 +2,6 @@ package zio.ftp
 
 import zio.ZIO.{ acquireRelease, attemptBlockingIO }
 import zio.ftp.StubFtp._
-import zio.nio.file.{ Files, Path => ZPath }
 import zio.stream.ZPipeline.utf8Decode
 import zio.stream.ZStream
 import zio.test.Assertion._
@@ -10,71 +9,73 @@ import zio.test._
 import zio.{ Chunk, Scope }
 
 import scala.io.Source
+import java.nio.file.{ Files, Path }
+import zio.ZIO
 
 object StubFtpSpec extends ZIOSpecDefault {
-  val home = ZPath("ftp-home/stub/home")
+  val home = Path.of("ftp-home/stub/home")
 
   override def spec =
     suite("StubFtpSpec")(
       test("ls")(
         for {
-          files <- ls("/").runFold(List.empty[String])((s, f) => f.path +: s)
-        } yield assert(files.reverse)(hasSameElements(List("/notes.txt", "/dir1")))
+          files <- ls(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
+        } yield assert(files.reverse)(hasSameElements(List(Path.of("/notes.txt"), Path.of("/dir1"))))
       ),
       test("ls with invalid directory")(
         for {
-          files <- ls("/dont-exist").runFold(List.empty[String])((s, f) => f.path +: s)
+          files <- ls(Path.of("/dont-exist")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(hasSameElements(Nil))
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant("/").runFold(List.empty[String])((s, f) => f.path +: s)
+          files <- lsDescendant(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(
-          hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
+          hasSameElements(List(Path.of("/notes.txt"), "/dir1/users.csv", "/dir1/console.dump"))
         )
       ),
       test("ls descendant with invalid directory")(
         for {
-          files <- lsDescendant("/dont-exist").runCollect
+          files <- lsDescendant(Path.of("/dont-exist")).runCollect
         } yield assertTrue(files == Chunk.empty)
       ),
       test("stat directory") {
         for {
 
-          file <- stat("/dir1")
-        } yield assertTrue(file.get.path == "/dir1") &&
+          file <- stat(Path.of("/dir1"))
+        } yield assertTrue(file.get.path == Path.of("/dir1")) &&
           assertTrue(file.get.isDirectory.get)
       },
       test("stat file") {
         for {
-          file <- stat("/dir1/console.dump")
-        } yield assertTrue(file.get.path == "/dir1/console.dump") &&
+          file <- stat(Path.of("/dir1/console.dump"))
+        } yield assertTrue(file.get.path == Path.of("/dir1/console.dump")) &&
           assertTrue(!file.get.isDirectory.get)
       },
       test("stat file does not exist") {
         for {
-          file <- stat("/wrong-path.xml")
+          file <- stat(Path.of("/wrong-path.xml"))
         } yield assertTrue(file.isEmpty)
       },
       test("stat directory does not exist") {
         for {
-          file <- stat("/wrong-path")
+          file <- stat(Path.of("/wrong-path"))
         } yield assertTrue(file.isEmpty)
       },
       test("readFile") {
         for {
-          content <- readFile("/notes.txt").via(utf8Decode).runCollect
+          content <- readFile(Path.of("/notes.txt")).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("""|Hello world !!!
                                                     |this is a beautiful day""".stripMargin))
       },
       test("readFile with offset") {
         for {
-          content <- readFile("/notes.txt", fileOffset = 16).via(utf8Decode).runCollect
+          content <- readFile(Path.of("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("this is a beautiful day"))
       },
       test("readFile does not exist") {
         for {
-          invalid <- readFile("/invalid.txt")
+          invalid <- readFile(Path.of("/invalid.txt"))
                        .via(utf8Decode)
                        .runCollect
                        .flip
@@ -84,77 +85,77 @@ object StubFtpSpec extends ZIOSpecDefault {
       },
       test("mkdir directory") {
         (for {
-          result <- mkdir("/new-dir").as(true)
-        } yield assertTrue(result)) <* Files.delete(home / "new-dir")
+          result <- mkdir(Path.of("/new-dir")).as(true)
+        } yield assertTrue(result)) <* ZIO.attempt(Files.delete(home.resolve("new-dir")))
       },
       test("mkdir fail when invalid path") {
         for {
-          failure <- mkdir("/dir1/users.csv").flip.map(_.getMessage)
+          failure <- mkdir(Path.of("/dir1/users.csv")).flip.map(_.getMessage)
         } yield assert(failure)(containsString("Path is invalid. Cannot create directory : /dir1/users.csv"))
       },
       test("rm valid path") {
-        val path = home / "to-delete.txt"
+        val path = home.resolve("to-delete.txt")
 
         for {
-          _       <- Files.createFile(path)
-          success <- rm("/to-delete.txt").as(true)
+          _       <- ZIO.attempt(Files.createFile(path))
+          success <- rm(Path.of("/to-delete.txt")).as(true)
 
-          fileExist <- Files.notExists(path)
+          fileExist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(success && fileExist)
       },
       test("rm fail when invalid path") {
         for {
-          invalid <- rm("/dont-exist").flip.map(_.getMessage)
+          invalid <- rm(Path.of("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "Path is invalid. Cannot delete : /dont-exist")
       },
       test("rm directory") {
-        val path = home / "dir-to-delete"
+        val path = home.resolve("dir-to-delete")
         for {
-          _     <- Files.createDirectory(path)
-          r     <- rmdir("/dir-to-delete").as(true)
-          exist <- Files.notExists(path)
+          _     <- ZIO.attempt(Files.createDirectory(path))
+          r     <- rmdir(Path.of("/dir-to-delete")).as(true)
+          exist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(r && exist)
       },
       test("rm fail invalid directory") {
         for {
-          r <- rmdir("/dont-exist").flip.map(_.getMessage)
+          r <- rmdir(Path.of("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(r == "Path is invalid. Cannot delete : /dont-exist")
       },
       test("upload a file") {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
-        val path = home / "hello-world.txt"
+        val path = home.resolve("hello-world.txt")
 
         (for {
-          _      <- upload("/hello-world.txt", data)
+          _      <- upload(Path.of("/hello-world.txt"), data)
           result <-
             acquireRelease(attemptBlockingIO(Source.fromFile(path.toFile)))(b => attemptBlockingIO(b.close()).ignore)
               .map(_.mkString)
 
-        } yield assert(result)(equalTo("Hello F World"))) <* Files.delete(path)
+        } yield assert(result)(equalTo("Hello F World"))) <* ZIO.attempt(Files.delete(path))
       },
       test("upload fail when path is invalid") {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
         for {
-          failure <- upload("/dont-exist/hello-world.txt", data).flip.map(_.getMessage)
+          failure <- upload(Path.of("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
 
         } yield assertTrue(failure == "Path is invalid. Cannot upload data to : /dont-exist/hello-world.txt")
       },
       test("rename a file") {
-        val oldPath = home / "to-rename.txt"
-        val newPath = home / "to-rename-destination.txt"
+        val oldPath = home.resolve("to-rename.txt")
+        val newPath = home.resolve("to-rename-destination.txt")
 
         (for {
-          _       <- Files.createFile(oldPath)
-          success <- rename("/to-rename.txt", "/to-rename-destination.txt").as(true)
+          _       <- ZIO.attempt(Files.createFile(oldPath))
+          success <- rename(Path.of("/to-rename.txt"), Path.of("/to-rename-destination.txt")).as(true)
 
-          oldFileExists <- Files.exists(oldPath)
-          newFileExists <- Files.exists(newPath)
-        } yield assertTrue(success && !oldFileExists && newFileExists)) <* Files.delete(newPath)
+          oldFileExists <- ZIO.attempt(Files.exists(oldPath))
+          newFileExists <- ZIO.attempt(Files.exists(newPath))
+        } yield assertTrue(success && !oldFileExists && newFileExists)) <* ZIO.attempt(Files.delete(newPath))
       },
       test("rename a file fails when old path doesn't exist") {
         for {
-          failure <- rename("/dont-exist.txt", "/dont-exist-destination.txt").flip.map(_.getMessage)
+          failure <- rename(Path.of("/dont-exist.txt"), Path.of("/dont-exist-destination.txt")).flip.map(_.getMessage)
         } yield assertTrue(failure == "Path is invalid. Cannot rename /dont-exist.txt to /dont-exist-destination.txt")
       }
     ).provideSomeLayerShared[Scope](stub(home))

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpReadFileSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpReadFileSpec.scala
@@ -6,7 +6,7 @@ import zio.test._
 
 import java.io.{ IOException, InputStream }
 import scala.util.Random
-import java.nio.file.Path
+import java.nio.file.Paths
 
 object UnsecureFtpReadFileSpec extends ZIOSpecDefault {
 
@@ -33,13 +33,13 @@ object UnsecureFtpReadFileSpec extends ZIOSpecDefault {
       test("succeed") {
         val ftpClient = createFtpclient(Right(true))
         for {
-          bytes <- ftpClient.readFile(Path.of("/a/b/c.txt")).runCollect
+          bytes <- ftpClient.readFile(Paths.get("/a/b/c.txt")).runCollect
         } yield assert(bytes)(hasSize(equalTo(5000)))
       },
       test("fail to complete") {
         val ftpClient = createFtpclient(Right(false))
         for {
-          exit <- ftpClient.readFile(Path.of("/a/b/c.txt")).runCollect.exit
+          exit <- ftpClient.readFile(Paths.get("/a/b/c.txt")).runCollect.exit
         } yield assert(exit)(
           fails(
             isSubtype[FileTransferIncompleteError](
@@ -51,7 +51,7 @@ object UnsecureFtpReadFileSpec extends ZIOSpecDefault {
       test("error occur") {
         val ftpClient = createFtpclient(Left(new IOException("Boom")))
         for {
-          exit <- ftpClient.readFile(Path.of("/a/b/c.txt")).runCollect.exit
+          exit <- ftpClient.readFile(Paths.get("/a/b/c.txt")).runCollect.exit
         } yield assert(exit)(
           fails(
             isSubtype[FileTransferIncompleteError](

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpReadFileSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpReadFileSpec.scala
@@ -6,6 +6,7 @@ import zio.test._
 
 import java.io.{ IOException, InputStream }
 import scala.util.Random
+import java.nio.file.Path
 
 object UnsecureFtpReadFileSpec extends ZIOSpecDefault {
 
@@ -32,13 +33,13 @@ object UnsecureFtpReadFileSpec extends ZIOSpecDefault {
       test("succeed") {
         val ftpClient = createFtpclient(Right(true))
         for {
-          bytes <- ftpClient.readFile("/a/b/c.txt").runCollect
+          bytes <- ftpClient.readFile(Path.of("/a/b/c.txt")).runCollect
         } yield assert(bytes)(hasSize(equalTo(5000)))
       },
       test("fail to complete") {
         val ftpClient = createFtpclient(Right(false))
         for {
-          exit <- ftpClient.readFile("/a/b/c.txt").runCollect.exit
+          exit <- ftpClient.readFile(Path.of("/a/b/c.txt")).runCollect.exit
         } yield assert(exit)(
           fails(
             isSubtype[FileTransferIncompleteError](
@@ -50,7 +51,7 @@ object UnsecureFtpReadFileSpec extends ZIOSpecDefault {
       test("error occur") {
         val ftpClient = createFtpclient(Left(new IOException("Boom")))
         for {
-          exit <- ftpClient.readFile("/a/b/c.txt").runCollect.exit
+          exit <- ftpClient.readFile(Path.of("/a/b/c.txt")).runCollect.exit
         } yield assert(exit)(
           fails(
             isSubtype[FileTransferIncompleteError](

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -10,9 +10,10 @@ import zio.stream.ZPipeline.utf8Decode
 import zio.stream.ZStream
 import java.net.{ InetSocketAddress, Proxy }
 import scala.io.Source
-import java.time.{ Instant, Duration => JDuration }
+import java.time.{ Duration => JDuration }
 import java.nio.file.Path
 import java.nio.file.Files
+import scala.util.chaining._
 
 object UnsecureSslFtpSpec extends ZIOSpecDefault {
   private val settings = UnsecureFtpSettings.secure("127.0.0.1", 2121, FtpCredentials("username", "userpass"))
@@ -63,8 +64,12 @@ object FtpSuite {
       ),
       test("timestamp")(
         for {
-          file <- ls(Path.of("/notes.txt")).runLast
-        } yield assertTrue(file.exists(r => JDuration.between(r.lastModified, Instant.now()).abs.toMinutes < 10))
+          file     <- ls(Path.of("/notes.txt")).runLast
+          filetime <- ZIO.attempt(Files.getLastModifiedTime(Path.of("ftp-home/sftp/home/foo/notes.txt")))
+
+        } yield assertTrue(
+          file.is(_.some).pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 1000)
+        )
       ),
       test("ls with invalid directory")(
         for {

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -68,7 +68,7 @@ object FtpSuite {
           filetime <- ZIO.attempt(Files.getLastModifiedTime(Paths.get("ftp-home/sftp/home/foo/notes.txt")))
 
         } yield assertTrue(
-          file.is(_.some).pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 1000)
+          file.is(_.some).pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 10000)
         )
       ),
       test("ls with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -10,10 +10,10 @@ import zio.stream.ZPipeline.utf8Decode
 import zio.stream.ZStream
 import java.net.{ InetSocketAddress, Proxy }
 import scala.io.Source
-import java.time.{ Duration => JDuration }
 import java.nio.file.{ Path, Paths }
 import java.nio.file.Files
-import scala.util.chaining._
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 
 object UnsecureSslFtpSpec extends ZIOSpecDefault {
   private val settings = UnsecureFtpSettings.secure("127.0.0.1", 2121, FtpCredentials("username", "userpass"))
@@ -68,7 +68,9 @@ object FtpSuite {
           filetime <- ZIO.attempt(Files.getLastModifiedTime(Paths.get("ftp-home/sftp/home/foo/notes.txt")))
 
         } yield assertTrue(
-          file.is(_.some).pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 10000)
+          file
+            .is(_.some)
+            .lastModified == filetime.toInstant().truncatedTo(ChronoUnit.SECONDS)
         )
       ),
       test("ls with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -86,7 +86,7 @@ object FtpSuite {
       test("stat directory") {
         for {
 
-          file <- stat(Path.of("/dir1)"))
+          file <- stat(Path.of("/dir1"))
         } yield assertTrue(file.get.path == Path.of("/dir1")) &&
           assertTrue(file.get.isDirectory.get)
       },

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -12,7 +12,6 @@ import java.net.{ InetSocketAddress, Proxy }
 import scala.io.Source
 import java.nio.file.{ Path, Paths }
 import java.nio.file.Files
-import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
 object UnsecureSslFtpSpec extends ZIOSpecDefault {
@@ -69,8 +68,7 @@ object FtpSuite {
 
         } yield assertTrue(
           file
-            .is(_.some)
-            .lastModified == filetime.toInstant().truncatedTo(ChronoUnit.SECONDS)
+            .exists(_.lastModified == filetime.toInstant().truncatedTo(ChronoUnit.MINUTES))
         )
       ),
       test("ls with invalid directory")(

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -6,13 +6,13 @@ import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.ftp.Ftp._
-import zio.nio.file.{ Path => ZPath }
-import zio.nio.file.Files
 import zio.stream.ZPipeline.utf8Decode
 import zio.stream.ZStream
 import java.net.{ InetSocketAddress, Proxy }
 import scala.io.Source
 import java.time.{ Instant, Duration => JDuration }
+import java.nio.file.Path
+import java.nio.file.Files
 
 object UnsecureSslFtpSpec extends ZIOSpecDefault {
   private val settings = UnsecureFtpSettings.secure("127.0.0.1", 2121, FtpCredentials("username", "userpass"))
@@ -29,7 +29,7 @@ object UnsecureFtpSpec extends ZIOSpecDefault {
 }
 
 object FtpSuite {
-  private val home = ZPath("ftp-home/ftp/home")
+  private val home = Path.of("ftp-home/ftp/home")
 
   def spec(labelSuite: String, settings: UnsecureFtpSettings) =
     suite(labelSuite)(
@@ -58,68 +58,68 @@ object FtpSuite {
       ),
       test("ls ")(
         for {
-          files <- ls("/").runFold(List.empty[String])((s, f) => f.path +: s)
-        } yield assert(files.reverse)(hasSameElements(List("/notes.txt", "/dir1")))
+          files <- ls(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
+        } yield assert(files.reverse)(hasSameElements(List(Path.of("/notes.txt"), Path.of("/dir1"))))
       ),
       test("timestamp")(
         for {
-          file <- ls("/notes.txt").runLast
+          file <- ls(Path.of("/notes.txt")).runLast
         } yield assertTrue(file.exists(r => JDuration.between(r.lastModified, Instant.now()).abs.toMinutes < 10))
       ),
       test("ls with invalid directory")(
         for {
-          files <- ls("/dont-exist").runFold(List.empty[String])((s, f) => f.path +: s)
+          files <- ls(Path.of("/dont-exist")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(hasSameElements(Nil))
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant("/").runFold(List.empty[String])((s, f) => f.path +: s)
+          files <- lsDescendant(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(
-          hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump"))
+          hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump").map(Path.of(_)))
         )
       ),
       test("ls descendant with invalid directory")(
         for {
-          files <- lsDescendant("/dont-exist").runCollect
+          files <- lsDescendant(Path.of("/dont-exist")).runCollect
         } yield assertTrue(files == Chunk.empty)
       ),
       test("stat directory") {
         for {
 
-          file <- stat("/dir1")
-        } yield assertTrue(file.get.path == "/dir1") &&
+          file <- stat(Path.of("/dir1)"))
+        } yield assertTrue(file.get.path == Path.of("/dir1")) &&
           assertTrue(file.get.isDirectory.get)
       },
       test("stat file") {
         for {
-          file <- stat("/dir1/console.dump")
-        } yield assertTrue(file.get.path == "/dir1/console.dump") &&
+          file <- stat(Path.of("/dir1/console.dump"))
+        } yield assertTrue(file.get.path == Path.of("/dir1/console.dump")) &&
           assertTrue(!file.get.isDirectory.get)
       },
       test("stat file does not exist") {
         for {
-          file <- stat("/wrong-path.xml")
+          file <- stat(Path.of("/wrong-path.xml"))
         } yield assertTrue(file.isEmpty)
       },
       test("stat directory does not exist") {
         for {
-          file <- stat("/wrong-path")
+          file <- stat(Path.of("/wrong-path"))
         } yield assertTrue(file.isEmpty)
       },
       test("readFile") {
         for {
-          content <- readFile("/notes.txt").via(utf8Decode).runCollect
+          content <- readFile(Path.of("/notes.txt")).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("""|Hello world !!!
                                                     |this is a beautiful day""".stripMargin))
       },
       test("readFile with offset") {
         for {
-          content <- readFile("/notes.txt", fileOffset = 16).via(utf8Decode).runCollect
+          content <- readFile(Path.of("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("this is a beautiful day"))
       },
       test("readFile does not exist") {
         for {
-          invalid <- readFile("/invalid.txt")
+          invalid <- readFile(Path.of("/invalid.txt"))
                        .via(utf8Decode)
                        .runCollect
                        .flip
@@ -130,80 +130,80 @@ object FtpSuite {
       test("mkdir directory") {
         (
           for {
-            result <- mkdir("/new-dir").as(true)
+            result <- mkdir(Path.of("/new-dir")).as(true)
           } yield assert(result)(equalTo(true))
-        ) <* Files.delete(home / "new-dir")
+        ) <* ZIO.attempt(Files.delete(home.resolve("new-dir")))
       },
       test("mkdir fail when invalid path") {
         for {
-          failure <- mkdir("/dir1/users.csv").flip.map(_.getMessage)
+          failure <- mkdir(Path.of("/dir1/users.csv")).flip.map(_.getMessage)
         } yield assert(failure)(containsString("Path is invalid. Cannot create directory : /dir1/users.csv"))
       },
       test("rm valid path") {
-        val path = home / "to-delete.txt"
+        val path = home.resolve("to-delete.txt")
 
         for {
-          _       <- Files.createFile(path)
-          success <- rm("/to-delete.txt").as(true)
+          _       <- ZIO.attempt(Files.createFile(path))
+          success <- rm(Path.of("/to-delete.txt")).as(true)
 
-          fileExist <- Files.notExists(path)
+          fileExist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(success && fileExist)
       },
       test("rm fail when invalid path") {
         for {
-          invalid <- rm("/dont-exist").flip.map(_.getMessage)
+          invalid <- rm(Path.of("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "Path is invalid. Cannot delete file : /dont-exist")
       },
       test("rm directory") {
-        val path = home / "dir-to-delete"
+        val path = home.resolve("dir-to-delete")
 
         for {
-          _     <- Files.createDirectory(path)
-          r     <- rmdir("/dir-to-delete").as(true)
-          exist <- Files.notExists(path)
+          _     <- ZIO.attempt(Files.createDirectory(path))
+          r     <- rmdir(Path.of("/dir-to-delete")).as(true)
+          exist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(r && exist)
       },
       test("rm fail invalid directory") {
         for {
-          r <- rmdir("/dont-exist")
+          r <- rmdir(Path.of("/dont-exist"))
                  .foldCause(_.failureOption.map(_.getMessage).getOrElse(""), _ => "")
         } yield assertTrue(r == "Path is invalid. Cannot delete directory : /dont-exist")
       },
       test("upload a file") {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
-        val path = home / "hello-world.txt"
+        val path = home.resolve("hello-world.txt")
 
         (for {
-          _      <- upload("/hello-world.txt", data)
+          _      <- upload(Path.of("/hello-world.txt"), data)
           result <-
             acquireRelease(attemptBlockingIO(Source.fromFile(path.toFile)))(b => attemptBlockingIO(b.close()).ignore)
               .map(_.mkString)
 
-        } yield assert(result)(equalTo("Hello F World"))) <* Files.delete(path)
+        } yield assert(result)(equalTo("Hello F World"))) <* ZIO.attempt(Files.delete(path))
       },
       test("upload fail when path is invalid") {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
         for {
-          failure <- upload("/dont-exist/hello-world.txt", data).flip.map(_.getMessage)
+          failure <- upload(Path.of("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
         } yield assertTrue(failure == "Path is invalid. Cannot upload data to : /dont-exist/hello-world.txt")
       },
       test("rename valid path") {
-        val oldPath = home / "to-rename.txt"
-        val newPath = home / "to-rename-destination.txt"
+        val oldPath = home.resolve("to-rename.txt")
+        val newPath = home.resolve("to-rename-destination.txt")
 
         (for {
-          _       <- Files.createFile(oldPath)
-          success <- rename("/to-rename.txt", "/to-rename-destination.txt").as(true)
+          _       <- ZIO.attempt(Files.createFile(oldPath))
+          success <- rename(Path.of("/to-rename.txt"), Path.of("/to-rename-destination.txt")).as(true)
 
-          oldFileExists <- Files.exists(oldPath)
-          newFileExists <- Files.exists(newPath)
-        } yield assertTrue(success && !oldFileExists && newFileExists)) <* Files.delete(newPath)
+          oldFileExists <- ZIO.attempt(Files.exists(oldPath))
+          newFileExists <- ZIO.attempt(Files.exists(newPath))
+        } yield assertTrue(success && !oldFileExists && newFileExists)) <* ZIO.attempt(Files.delete(newPath))
       },
       test("rename fail when invalid path") {
         for {
-          invalid <- rename("/dont-exist", "/dont-exist-destination").flip.map(_.getMessage)
+          invalid <- rename(Path.of("/dont-exist"), Path.of("/dont-exist-destination")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "Path is invalid. Cannot rename /dont-exist to /dont-exist-destination")
       },
       test("call noOp underlying client") {

--- a/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
+++ b/zio-ftp/src/test/scala/zio/ftp/UnsecureFtpSpec.scala
@@ -11,7 +11,7 @@ import zio.stream.ZStream
 import java.net.{ InetSocketAddress, Proxy }
 import scala.io.Source
 import java.time.{ Duration => JDuration }
-import java.nio.file.Path
+import java.nio.file.{ Path, Paths }
 import java.nio.file.Files
 import scala.util.chaining._
 
@@ -30,7 +30,7 @@ object UnsecureFtpSpec extends ZIOSpecDefault {
 }
 
 object FtpSuite {
-  private val home = Path.of("ftp-home/ftp/home")
+  private val home = Paths.get("ftp-home/ftp/home")
 
   def spec(labelSuite: String, settings: UnsecureFtpSettings) =
     suite(labelSuite)(
@@ -59,13 +59,13 @@ object FtpSuite {
       ),
       test("ls ")(
         for {
-          files <- ls(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
-        } yield assert(files.reverse)(hasSameElements(List(Path.of("/notes.txt"), Path.of("/dir1"))))
+          files <- ls(Paths.get("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
+        } yield assert(files.reverse)(hasSameElements(List(Paths.get("/notes.txt"), Paths.get("/dir1"))))
       ),
       test("timestamp")(
         for {
-          file     <- ls(Path.of("/notes.txt")).runLast
-          filetime <- ZIO.attempt(Files.getLastModifiedTime(Path.of("ftp-home/sftp/home/foo/notes.txt")))
+          file     <- ls(Paths.get("/notes.txt")).runLast
+          filetime <- ZIO.attempt(Files.getLastModifiedTime(Paths.get("ftp-home/sftp/home/foo/notes.txt")))
 
         } yield assertTrue(
           file.is(_.some).pipe(r => JDuration.between(r.lastModified, filetime.toInstant()).abs.toMillis < 1000)
@@ -73,58 +73,58 @@ object FtpSuite {
       ),
       test("ls with invalid directory")(
         for {
-          files <- ls(Path.of("/dont-exist")).runFold(List.empty[Path])((s, f) => f.path +: s)
+          files <- ls(Paths.get("/dont-exist")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(hasSameElements(Nil))
       ),
       test("ls descendant")(
         for {
-          files <- lsDescendant(Path.of("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
+          files <- lsDescendant(Paths.get("/")).runFold(List.empty[Path])((s, f) => f.path +: s)
         } yield assert(files.reverse)(
-          hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump").map(Path.of(_)))
+          hasSameElements(List("/notes.txt", "/dir1/users.csv", "/dir1/console.dump").map(Paths.get(_)))
         )
       ),
       test("ls descendant with invalid directory")(
         for {
-          files <- lsDescendant(Path.of("/dont-exist")).runCollect
+          files <- lsDescendant(Paths.get("/dont-exist")).runCollect
         } yield assertTrue(files == Chunk.empty)
       ),
       test("stat directory") {
         for {
 
-          file <- stat(Path.of("/dir1"))
-        } yield assertTrue(file.get.path == Path.of("/dir1")) &&
+          file <- stat(Paths.get("/dir1"))
+        } yield assertTrue(file.get.path == Paths.get("/dir1")) &&
           assertTrue(file.get.isDirectory.get)
       },
       test("stat file") {
         for {
-          file <- stat(Path.of("/dir1/console.dump"))
-        } yield assertTrue(file.get.path == Path.of("/dir1/console.dump")) &&
+          file <- stat(Paths.get("/dir1/console.dump"))
+        } yield assertTrue(file.get.path == Paths.get("/dir1/console.dump")) &&
           assertTrue(!file.get.isDirectory.get)
       },
       test("stat file does not exist") {
         for {
-          file <- stat(Path.of("/wrong-path.xml"))
+          file <- stat(Paths.get("/wrong-path.xml"))
         } yield assertTrue(file.isEmpty)
       },
       test("stat directory does not exist") {
         for {
-          file <- stat(Path.of("/wrong-path"))
+          file <- stat(Paths.get("/wrong-path"))
         } yield assertTrue(file.isEmpty)
       },
       test("readFile") {
         for {
-          content <- readFile(Path.of("/notes.txt")).via(utf8Decode).runCollect
+          content <- readFile(Paths.get("/notes.txt")).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("""|Hello world !!!
                                                     |this is a beautiful day""".stripMargin))
       },
       test("readFile with offset") {
         for {
-          content <- readFile(Path.of("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
+          content <- readFile(Paths.get("/notes.txt"), fileOffset = 16).via(utf8Decode).runCollect
         } yield assert(content.mkString)(equalTo("this is a beautiful day"))
       },
       test("readFile does not exist") {
         for {
-          invalid <- readFile(Path.of("/invalid.txt"))
+          invalid <- readFile(Paths.get("/invalid.txt"))
                        .via(utf8Decode)
                        .runCollect
                        .flip
@@ -135,13 +135,13 @@ object FtpSuite {
       test("mkdir directory") {
         (
           for {
-            result <- mkdir(Path.of("/new-dir")).as(true)
+            result <- mkdir(Paths.get("/new-dir")).as(true)
           } yield assert(result)(equalTo(true))
         ) <* ZIO.attempt(Files.delete(home.resolve("new-dir")))
       },
       test("mkdir fail when invalid path") {
         for {
-          failure <- mkdir(Path.of("/dir1/users.csv")).flip.map(_.getMessage)
+          failure <- mkdir(Paths.get("/dir1/users.csv")).flip.map(_.getMessage)
         } yield assert(failure)(containsString("Path is invalid. Cannot create directory : /dir1/users.csv"))
       },
       test("rm valid path") {
@@ -149,14 +149,14 @@ object FtpSuite {
 
         for {
           _       <- ZIO.attempt(Files.createFile(path))
-          success <- rm(Path.of("/to-delete.txt")).as(true)
+          success <- rm(Paths.get("/to-delete.txt")).as(true)
 
           fileExist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(success && fileExist)
       },
       test("rm fail when invalid path") {
         for {
-          invalid <- rm(Path.of("/dont-exist")).flip.map(_.getMessage)
+          invalid <- rm(Paths.get("/dont-exist")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "Path is invalid. Cannot delete file : /dont-exist")
       },
       test("rm directory") {
@@ -164,13 +164,13 @@ object FtpSuite {
 
         for {
           _     <- ZIO.attempt(Files.createDirectory(path))
-          r     <- rmdir(Path.of("/dir-to-delete")).as(true)
+          r     <- rmdir(Paths.get("/dir-to-delete")).as(true)
           exist <- ZIO.attempt(Files.notExists(path))
         } yield assertTrue(r && exist)
       },
       test("rm fail invalid directory") {
         for {
-          r <- rmdir(Path.of("/dont-exist"))
+          r <- rmdir(Paths.get("/dont-exist"))
                  .foldCause(_.failureOption.map(_.getMessage).getOrElse(""), _ => "")
         } yield assertTrue(r == "Path is invalid. Cannot delete directory : /dont-exist")
       },
@@ -180,7 +180,7 @@ object FtpSuite {
         val path = home.resolve("hello-world.txt")
 
         (for {
-          _      <- upload(Path.of("/hello-world.txt"), data)
+          _      <- upload(Paths.get("/hello-world.txt"), data)
           result <-
             acquireRelease(attemptBlockingIO(Source.fromFile(path.toFile)))(b => attemptBlockingIO(b.close()).ignore)
               .map(_.mkString)
@@ -191,7 +191,7 @@ object FtpSuite {
         val data = ZStream.fromChunks(Chunk.fromArray("Hello F World".getBytes))
 
         for {
-          failure <- upload(Path.of("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
+          failure <- upload(Paths.get("/dont-exist/hello-world.txt"), data).flip.map(_.getMessage)
         } yield assertTrue(failure == "Path is invalid. Cannot upload data to : /dont-exist/hello-world.txt")
       },
       test("rename valid path") {
@@ -200,7 +200,7 @@ object FtpSuite {
 
         (for {
           _       <- ZIO.attempt(Files.createFile(oldPath))
-          success <- rename(Path.of("/to-rename.txt"), Path.of("/to-rename-destination.txt")).as(true)
+          success <- rename(Paths.get("/to-rename.txt"), Paths.get("/to-rename-destination.txt")).as(true)
 
           oldFileExists <- ZIO.attempt(Files.exists(oldPath))
           newFileExists <- ZIO.attempt(Files.exists(newPath))
@@ -208,7 +208,7 @@ object FtpSuite {
       },
       test("rename fail when invalid path") {
         for {
-          invalid <- rename(Path.of("/dont-exist"), Path.of("/dont-exist-destination")).flip.map(_.getMessage)
+          invalid <- rename(Paths.get("/dont-exist"), Paths.get("/dont-exist-destination")).flip.map(_.getMessage)
         } yield assertTrue(invalid == "Path is invalid. Cannot rename /dont-exist to /dont-exist-destination")
       },
       test("call noOp underlying client") {


### PR DESCRIPTION
zio-nio is dead and archived and needs to be removed.
I also replace all String paths with Path objects. 
